### PR TITLE
Copy only after `concat` args traversal

### DIFF
--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -488,29 +488,19 @@ impl ComplexWord for Concat {
         // Traverse the two arguments, setting up the stack to contain the
         // arguments to the subsequent `memory.copy` instructions
 
-        /* [] */
         builder.local_get(ret_off);
-        /* [ret_off] */
         generator.traverse_expr(builder, lhs_expr)?;
         builder.local_tee(lhs_len);
-        /* [ret_off, lhs_off, lhs_len] */
         builder.local_get(ret_off);
-        /* [ret_off, lhs_off, lhs_len, ret_off] */
         builder.local_get(lhs_len);
-        /* [ret_off, lhs_off, lhs_len, ret_off, lhs_len] */
         builder.binop(BinaryOp::I32Add);
-        /* [ret_off, lhs_off, lhs_len, ret_off + lhs_len] */
         generator.traverse_expr(builder, rhs_expr)?;
         builder.local_tee(rhs_len);
-        /* [ret_off, lhs_off, lhs_len, ret_off + lhs_len, rhs_off, rhs_len] */
 
         // Copy arguments to the return buffer. RHS is copied 1st, and LHS 2nd
 
-        /* [ret_off, lhs_off, lhs_len, ret_off + lhs_len, rhs_off, rhs_len] */
         builder.memory_copy(memory, memory);
-        /* [ret_off, lhs_off, lhs_len] */
         builder.memory_copy(memory, memory);
-        /* [] */
 
         // Set up the returns representing the new sequence [ret_off, ret_len]
 

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -481,10 +481,6 @@ impl ComplexWord for Concat {
         let lhs_len = generator.module.locals.add(ValType::I32);
         let rhs_len = generator.module.locals.add(ValType::I32);
 
-        // WORKAROUND: typechecker issue for lists
-        generator.set_expr_type(lhs_expr, ret_ty.clone())?;
-        generator.set_expr_type(rhs_expr, ret_ty)?;
-
         // Traverse the two arguments, setting up the stack to contain the
         // arguments to the subsequent `memory.copy` instructions
 


### PR DESCRIPTION
Code generated for the `concat` word is changed to ensure both its arguments are traversed *before* copying their contents onto the resulting sequence.

This avoids a partially copied to return buffer should the code fail during resolution of the second argument. It will also allow for a cleaner implementation of cost tracking since we can then also avoid copying on a cost overrun.

See-also: #616
