### PR TITLE
Chore: stacks core sync

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
     needs: [fmt, clippy]
     strategy:
       matrix:
-        clarity_version: [1, 2, 3, 4, 5]
+        clarity_version: [1, 2, 3, 4, 5, 6]
 
     name: Clarity::V${{ matrix.clarity_version }} Artifacts
     steps:
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clarity_version: [1, 2, 3, 4, 5]
+        clarity_version: [1, 2, 3, 4, 5, 6]
     name: Clarity::V${{ matrix.clarity_version }} Tests
     steps:
       - name: Checkout PR

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clarity_version: [1, 2, 3, 4, 5]
+        clarity_version: [1, 2, 3, 4, 5, 6]
     name: Clarity::V${{ matrix.clarity_version }} Property Tests
     env:
       PROPTEST_CASES: 100

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#1d786f79a10a449cb26e75f708c2d5ad79ad2df4"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#79e9b6428a12d1a5050f371dfb85585bce73d00f"
 dependencies = [
  "clarity-types",
  "hashbrown 0.15.5",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "clarity-types"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#1d786f79a10a449cb26e75f708c2d5ad79ad2df4"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#79e9b6428a12d1a5050f371dfb85585bce73d00f"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#1d786f79a10a449cb26e75f708c2d5ad79ad2df4"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#79e9b6428a12d1a5050f371dfb85585bce73d00f"
 dependencies = [
  "chrono",
  "curve25519-dalek",

--- a/clar2wasm/Cargo.toml
+++ b/clar2wasm/Cargo.toml
@@ -14,9 +14,9 @@ sha2 = { version = "0.10.7" }
 chrono = { version = "0.4.20" }
 rusqlite = { version = "0.31.0" }
 
-clarity = { git="https://github.com/stacks-network/stacks-core", branch="feat/clarity-wasm-develop" }
-stacks-common = { git="https://github.com/stacks-network/stacks-core", branch="feat/clarity-wasm-develop" }
-clarity-types = { git="https://github.com/stacks-network/stacks-core", branch="feat/clarity-wasm-develop" }
+clarity = { git = "https://github.com/stacks-network/stacks-core", branch = "feat/clarity-wasm-develop" }
+stacks-common = { git = "https://github.com/stacks-network/stacks-core", branch = "feat/clarity-wasm-develop" }
+clarity-types = { git = "https://github.com/stacks-network/stacks-core", branch = "feat/clarity-wasm-develop" }
 
 [build-dependencies]
 wat = "1.0.74"
@@ -33,10 +33,11 @@ test-clarity-v2 = []
 test-clarity-v3 = []
 test-clarity-v4 = []
 test-clarity-v5 = []
+test-clarity-v6 = []
 developer-mode = []
 
 [dev-dependencies]
-clar2wasm = {path = ".", features = ["developer-mode"]}
+clar2wasm = { path = ".", features = ["developer-mode"] }
 criterion = "0.5"
 proptest = "1.2.0"
 num-integer = { version = "0.1.45", default-features = false }

--- a/clar2wasm/benches/comparison.rs
+++ b/clar2wasm/benches/comparison.rs
@@ -11,10 +11,12 @@ use clarity::util::hash::Keccak256Hash;
 use clarity::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 use clarity::vm::analysis::{run_analysis, AnalysisDatabase};
 use clarity::vm::ast::build_ast_with_diagnostics;
-use clarity::vm::contexts::{ExecutionState, GlobalContext, InvocationContext};
+use clarity::vm::contexts::{
+    ExecutionState, FunctionExecutionOptions, GlobalContext, InvocationContext,
+};
 use clarity::vm::costs::LimitedCostTracker;
 use clarity::vm::database::{ClarityDatabase, MemoryBackingStore};
-use clarity::vm::time_tracker::TimeTracker;
+use clarity::vm::resource_limiter::ResourceLimiter;
 use clarity::vm::types::{QualifiedContractIdentifier, StandardPrincipalData, TupleData};
 use clarity::vm::{
     eval_all, CallStack, ClarityName, ClarityVersion, ContractContext, ContractName, Value,
@@ -75,7 +77,7 @@ where
         StacksEpochId::latest(),
         ClarityVersion::latest(),
         true,
-        TimeTracker::unlimited(),
+        ResourceLimiter::unlimited(),
     )
     .expect("Failed to run analysis");
 
@@ -119,7 +121,12 @@ where
 
     b.iter(|| {
         exec_state
-            .execute_function_as_transaction(&invoke_ctx, &func, &args, None, false)
+            .execute_function_as_transaction(
+                &invoke_ctx,
+                &func,
+                &args,
+                FunctionExecutionOptions::default(),
+            )
             .expect("Function call failed");
     });
 
@@ -206,7 +213,12 @@ where
 
     b.iter(|| {
         exec_state
-            .execute_function_as_transaction(&invoke_ctx, &func, &args, None, false)
+            .execute_function_as_transaction(
+                &invoke_ctx,
+                &func,
+                &args,
+                FunctionExecutionOptions::default(),
+            )
             .expect("Function call failed");
     });
 
@@ -502,8 +514,7 @@ fn add_prices_init(
                 Value::UInt(source),
                 Value::buff_from(pk.to_bytes_compressed()).unwrap(),
             ],
-            None,
-            false,
+            FunctionExecutionOptions::default(),
         )
         .expect("Adding source should succeed");
 

--- a/clar2wasm/src/bin/utils/mod.rs
+++ b/clar2wasm/src/bin/utils/mod.rs
@@ -52,6 +52,8 @@ impl ValueEnum for WrappedEpochId {
             StacksEpochId::Epoch32 => Some(PossibleValue::new("3.2")),
             StacksEpochId::Epoch33 => Some(PossibleValue::new("3.3")),
             StacksEpochId::Epoch34 => Some(PossibleValue::new("3.4")),
+            StacksEpochId::Epoch40 => Some(PossibleValue::new("4.0")),
+            StacksEpochId::Epoch41 => Some(PossibleValue::new("4.1")),
         }
     }
 }
@@ -88,6 +90,7 @@ impl ValueEnum for WrappedClarityVersion {
             ClarityVersion::Clarity3 => Some(PossibleValue::new("3")),
             ClarityVersion::Clarity4 => Some(PossibleValue::new("4")),
             ClarityVersion::Clarity5 => Some(PossibleValue::new("5")),
+            ClarityVersion::Clarity6 => Some(PossibleValue::new("6")),
         }
     }
 }

--- a/clar2wasm/src/cost.rs
+++ b/clar2wasm/src/cost.rs
@@ -185,6 +185,8 @@ impl ChargeContext {
             | StacksEpochId::Epoch32 => clar3::WORD_COSTS.get(name),
             StacksEpochId::Epoch33 => clar4::WORD_COSTS.get(name),
             StacksEpochId::Epoch34 => todo!(),
+            StacksEpochId::Epoch40 => todo!(),
+            StacksEpochId::Epoch41 => todo!(),
         }
     }
 }

--- a/clar2wasm/src/datastore.rs
+++ b/clar2wasm/src/datastore.rs
@@ -568,6 +568,10 @@ impl BurnStateDB for BurnDatastore {
         0
     }
 
+    fn get_pox_5_activation_height(&self) -> u32 {
+        0
+    }
+
     fn get_pox_prepare_length(&self) -> u32 {
         self.constants.pox_prepare_length
     }

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -3,7 +3,7 @@ use clarity::vm::analysis::{run_analysis, AnalysisDatabase, ContractAnalysis};
 use clarity::vm::ast::{build_ast_with_diagnostics, ContractAST};
 use clarity::vm::costs::{ExecutionCost, LimitedCostTracker};
 use clarity::vm::diagnostic::Diagnostic;
-use clarity::vm::time_tracker::TimeTracker;
+use clarity::vm::resource_limiter::ResourceLimiter;
 use clarity::vm::types::QualifiedContractIdentifier;
 use clarity::vm::ClarityVersion;
 pub use walrus::Module;
@@ -95,7 +95,7 @@ pub fn compile(
         epoch,
         clarity_version,
         true,
-        TimeTracker::unlimited(),
+        ResourceLimiter::unlimited(),
     ) {
         Ok(contract_analysis) => contract_analysis,
         Err(boxed) => {

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -2008,12 +2008,21 @@ fn link_stx_account_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), Vm
                     .global_context
                     .database
                     .get_v3_unlock_height()?;
+                let v4_unlock_ht = caller
+                    .data_mut()
+                    .global_context
+                    .database
+                    .get_v4_unlock_height()?;
 
                 let locked = account.amount_locked();
                 let locked_high = (locked >> 64) as u64;
                 let locked_low = (locked & 0xffff_ffff_ffff_ffff) as u64;
-                let unlock_height =
-                    account.effective_unlock_height(v1_unlock_ht, v2_unlock_ht, v3_unlock_ht);
+                let unlock_height = account.effective_unlock_height(
+                    v1_unlock_ht,
+                    v2_unlock_ht,
+                    v3_unlock_ht,
+                    v4_unlock_ht,
+                );
                 let unlocked = account.amount_unlocked();
                 let unlocked_high = (unlocked >> 64) as u64;
                 let unlocked_low = (unlocked & 0xffff_ffff_ffff_ffff) as u64;

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -550,22 +550,67 @@ struct CrossEvalResult {
 enum KnownBug {
     /// [https://github.com/stacks-network/stacks-core/issues/4622]
     ListOfQualifiedPrincipal,
+    /// A string literal ending with a backslash cannot be lexed by the parser v1.
+    StringEndingWithBackslash,
 }
 
 impl KnownBug {
     fn check_for_known_bugs(
         compiled: &Result<Option<Value>, VmExecutionError>,
         interpreted: &Result<Option<Value>, VmExecutionError>,
+        snippet: &str,
+        version: ClarityVersion,
+        epoch: StacksEpochId,
     ) -> Option<Self> {
         let check_predicate = |pred: &dyn Fn(&VmExecutionError) -> bool| {
             interpreted.as_ref().is_err_and(pred) && compiled.as_ref().is_err_and(pred)
         };
 
+        // The parser v1 is used below epoch 2.1, and Clarity 1 is the only
+        // version available on those epochs.
+        let uses_parser_v1 = epoch < StacksEpochId::Epoch21 && version == ClarityVersion::Clarity1;
+
         if check_predicate(&Self::has_list_of_qualified_principal_issue) {
             Some(KnownBug::ListOfQualifiedPrincipal)
+        } else if uses_parser_v1 && Self::has_string_ending_with_backslash(snippet) {
+            Some(KnownBug::StringEndingWithBackslash)
         } else {
             None
         }
+    }
+
+    /// Allows to detect if a snippet contains a string literal ending with a
+    /// backslash, which the parser v1 cannot lex.
+    ///
+    /// The parser v1 matches string literals with the regex
+    /// `"(?P<value>((\\")|([[ -~]&&[^"]]))*)"`, which prefers the escaped quote
+    /// alternative over a single character. When the last character of a string
+    /// is a backslash, the closing quote is consumed as part of a `\"` escape and
+    /// the literal keeps running until the next quote of the source.
+    fn has_string_ending_with_backslash(snippet: &str) -> bool {
+        let mut chars = snippet.chars();
+
+        while let Some(c) = chars.next() {
+            if c != '"' {
+                continue;
+            }
+
+            // inside a string literal, until its closing quote
+            let mut ends_with_backslash = false;
+            while let Some(c) = chars.next() {
+                match c {
+                    '\\' => ends_with_backslash = chars.next() == Some('\\'),
+                    '"' => break,
+                    _ => ends_with_backslash = false,
+                }
+            }
+
+            if ends_with_backslash {
+                return true;
+            }
+        }
+
+        false
     }
 
     /// Allows to detect if an error suffers from this issue:
@@ -603,13 +648,15 @@ impl CrossEvalResult {
 }
 
 fn crosseval(snippet: &str, env: TestEnvironment) -> Result<CrossEvalResult, KnownBug> {
+    let (version, epoch) = (env.version, env.epoch);
+
     let mut env_interpreted = env.clone();
     let interpreted = env_interpreted.interpret(snippet);
 
     let mut env_compiled = env;
     let compiled = env_compiled.evaluate(snippet);
 
-    match KnownBug::check_for_known_bugs(&compiled, &interpreted) {
+    match KnownBug::check_for_known_bugs(&compiled, &interpreted, snippet, version, epoch) {
         Some(bug) => {
             println!("KNOW BUG TRIGGERED <{bug:?}>:\n\t{snippet}");
             Err(bug)
@@ -821,6 +868,8 @@ pub fn crosscheck_multi_contract_with_env(
     expected: Result<Option<Value>, VmExecutionError>,
     env: TestEnvironment,
 ) {
+    let (version, epoch) = (env.version, env.epoch);
+
     // compiled version
     let mut compiled_env = env.clone();
     let compiled_results: Vec<_> = contracts
@@ -836,11 +885,18 @@ pub fn crosscheck_multi_contract_with_env(
         .collect();
 
     // compare results contract by contract
-    for ((cmp_res, int_res), (contract_name, _)) in compiled_results
+    for ((cmp_res, int_res), (contract_name, snippet)) in compiled_results
         .iter()
         .zip(interpreted_results)
         .zip(contracts)
     {
+        if let Some(bug) =
+            KnownBug::check_for_known_bugs(cmp_res, &int_res, snippet, version, epoch)
+        {
+            println!("KNOW BUG TRIGGERED <{bug:?}>:\n\t{snippet}");
+            return;
+        }
+
         assert_eq!(
             cmp_res, &int_res,
             "Compiled and interpreted results diverge in contract \"{contract_name}\"\ncompiled: {cmp_res:?}\ninterpreted: {int_res:?}"
@@ -1315,6 +1371,50 @@ mod tests {
         "#;
             let res = interpret(snippet_different_err).expect_err("Should detect a syntax error");
             assert!(!KnownBug::has_list_of_qualified_principal_issue(&res));
+        }
+    }
+
+    #[test]
+    fn detect_string_ending_with_backslash_issue() {
+        // A second string literal is needed after the offending one: the parser
+        // v1 extends the first literal up to the next quote of the source, and
+        // resumes lexing on the content of the second one. Depending on that
+        // content, the failure is either an unlexable remainder or a missing
+        // separator.
+        for snippet in [
+            r#"(list "a\\" "\\")"#,
+            r#"(list u"a\\" u"\\")"#,
+            r#"(list "a\\" "b")"#,
+            r#"(list u"a\\" u"b")"#,
+            r#"(list "\"a\\" "b")"#,
+            r#"(list u"\u{1F600}a\\" u"b")"#,
+        ] {
+            let bug = crosseval(
+                snippet,
+                TestEnvironment::new(StacksEpochId::Epoch2_05, ClarityVersion::Clarity1),
+            )
+            .err()
+            .expect("Snippet should trigger the known bug");
+            assert!(matches!(bug, KnownBug::StringEndingWithBackslash));
+
+            // The parser v2, used from epoch 2.1 on, lexes those snippets fine.
+            crosseval(
+                snippet,
+                TestEnvironment::new(TestConfig::latest_epoch(), ClarityVersion::Clarity1),
+            )
+            .unwrap_or_else(|bug| panic!("Unexpected known bug <{bug:?}>"))
+            .compare(snippet);
+        }
+
+        // A backslash which is not the last character of a string is lexed
+        // correctly, even by the parser v1.
+        for snippet in [r#"(list "a\\b" "c")"#, r#"(list u"a\\b" u"c")"#] {
+            crosseval(
+                snippet,
+                TestEnvironment::new(StacksEpochId::Epoch2_05, ClarityVersion::Clarity1),
+            )
+            .unwrap_or_else(|bug| panic!("Unexpected known bug <{bug:?}>"))
+            .compare(snippet);
         }
     }
 

--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -17,7 +17,7 @@ use clarity::vm::costs::{CostTracker, ExecutionCost, LimitedCostTracker};
 use clarity::vm::database::ClarityDatabase;
 use clarity::vm::errors::{StaticCheckErrorKind, VmExecutionError, WasmError};
 use clarity::vm::events::{SmartContractEventData, StacksTransactionEvent};
-use clarity::vm::time_tracker::TimeTracker;
+use clarity::vm::resource_limiter::ResourceLimiter;
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData};
 use clarity::vm::{eval_all, ClarityVersion, ContractContext, ContractName, Value};
 use clarity_types::types::TypeSignature;
@@ -358,7 +358,7 @@ impl TestEnvironment {
                     self.epoch,
                     self.version,
                     true,
-                    TimeTracker::unlimited(),
+                    ResourceLimiter::unlimited(),
                 )
                 .map_err(|boxed| StaticCheckErrorKind::Unreachable(format!("{:?}", boxed.0)))
             })
@@ -428,7 +428,8 @@ impl TestEnvironment {
 
 impl Default for TestEnvironment {
     fn default() -> Self {
-        Self::new(TestConfig::latest_epoch(), TestConfig::clarity_version())
+        let version = TestConfig::clarity_version();
+        Self::new(TestConfig::epoch_for_version(version), version)
     }
 }
 
@@ -466,10 +467,12 @@ pub fn evaluate_at_with_amount(
     env.evaluate(snippet)
 }
 
-/// Evaluate a Clarity snippet at the latest epoch and clarity version.
+/// Evaluate a Clarity snippet at the clarity version selected by the
+/// `test-clarity-vN` features (latest if none is set) and its matching epoch.
 /// Returns an optional value -- the result of the evaluation.
 pub fn evaluate(snippet: &str) -> Result<Option<Value>, VmExecutionError> {
-    evaluate_at(snippet, StacksEpochId::latest(), ClarityVersion::latest())
+    let version = TestConfig::clarity_version();
+    evaluate_at(snippet, TestConfig::epoch_for_version(version), version)
 }
 
 /// Interpret a Clarity snippet at a specific epoch and version.
@@ -496,10 +499,15 @@ pub fn interpret_at_with_amount(
     env.interpret(snippet)
 }
 
-/// Interprets a Clarity snippet at the latest epoch and clarity version.
+/// Interprets a Clarity snippet at the clarity version selected by the
+/// `test-clarity-vN` features (latest if none is set) and its matching epoch.
+///
+/// Must stay in sync with [`evaluate`]: `crosscheck_expect_failure` compares
+/// the two, so they have to run at the same version and epoch.
 /// Returns an optional value -- the result of the evaluation.
 pub fn interpret(snippet: &str) -> Result<Option<Value>, VmExecutionError> {
-    interpret_at(snippet, StacksEpochId::latest(), ClarityVersion::latest())
+    let version = TestConfig::clarity_version();
+    interpret_at(snippet, TestConfig::epoch_for_version(version), version)
 }
 
 pub struct TestConfig;
@@ -775,6 +783,21 @@ pub fn crosscheck_with_clarity_version(
     crosscheck_with_epoch_and_version(snippet, expected, TestConfig::latest_epoch(), version)
 }
 
+/// Crosscheck at the latest epoch, using the clarity version selected by the
+/// `test-clarity-vN` features. Use this for tests whose snippet needs a recent
+/// epoch even when an older clarity version is selected.
+pub fn crosscheck_with_latest_epoch(
+    snippet: &str,
+    expected: Result<Option<Value>, VmExecutionError>,
+) {
+    crosscheck_with_epoch_and_version(
+        snippet,
+        expected,
+        TestConfig::latest_epoch(),
+        TestConfig::clarity_version(),
+    )
+}
+
 pub fn crosscheck_validate<V: Fn(Value)>(snippet: &str, validator: V) {
     if let Some(eval) = execute_crosscheck(
         TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version()),
@@ -840,8 +863,15 @@ pub fn crosscheck_multi_contract_with_env(
 // Consider gating tests to epochs whenever possible
 // using the `crosscheck_with_epoch` function.
 pub fn crosscheck_expect_failure(snippet: &str) {
-    let compiled = evaluate(snippet);
-    let interpreted = interpret(snippet);
+    crosscheck_expect_failure_with_clarity_version(snippet, TestConfig::clarity_version())
+}
+
+/// Same as [`crosscheck_expect_failure`], but at an explicit clarity version
+/// instead of the one selected by the `test-clarity-vN` features.
+pub fn crosscheck_expect_failure_with_clarity_version(snippet: &str, version: ClarityVersion) {
+    let epoch = TestConfig::epoch_for_version(version);
+    let compiled = evaluate_at(snippet, epoch, version);
+    let interpreted = interpret_at(snippet, epoch, version);
 
     assert!(
         interpreted.is_err(),
@@ -1188,14 +1218,16 @@ mod tests {
     fn detect_list_of_qualified_principal_issue() {
         let snippet_no_wrap = r#"(index-of (list 'S53AR76V04QBY9CKZFQZ6FZF0730CEQS2AH761HTX.FoUtMZdXvouVYyvtvceMcRGotjQlzb) 'S53AR76V04QBY9CKZFQZ6FZF0730CEQS2AH761HTX.FoUtMZdXvouVYyvtvceMcRGotjQlzb)"#;
 
-        let e = interpret(snippet_no_wrap).expect_err("Snippet should err due to bug");
-        assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
-        crosscheck_with_epoch_and_version(
+        // Pinned to the latest epoch: the bug being detected only reproduces
+        // there, and `TestConfig` pairs Clarity 1 with Epoch 2.05.
+        let e = interpret_at(
             snippet_no_wrap,
-            Ok(None),
             TestConfig::latest_epoch(),
             TestConfig::clarity_version(),
-        ); // we don't care about the expected result
+        )
+        .expect_err("Snippet should err due to bug");
+        assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
+        crosscheck_with_latest_epoch(snippet_no_wrap, Ok(None)); // we don't care about the expected result
 
         let e = interpret_at(
             snippet_no_wrap,
@@ -1204,23 +1236,18 @@ mod tests {
         )
         .expect_err("Snippet should err due to bug");
         assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
-        crosscheck_with_epoch_and_version(
-            snippet_no_wrap,
-            Ok(None),
-            TestConfig::latest_epoch(),
-            TestConfig::clarity_version(),
-        ); // we don't care about the expected result
+        crosscheck_with_latest_epoch(snippet_no_wrap, Ok(None)); // we don't care about the expected result
 
         let snippet_simple = r#"(index-of (list (some 'S53AR76V04QBY9CKZFQZ6FZF0730CEQS2AH761HTX.FoUtMZdXvouVYyvtvceMcRGotjQlzb)) (some 'S53AR76V04QBY9CKZFQZ6FZF0730CEQS2AH761HTX.FoUtMZdXvouVYyvtvceMcRGotjQlzb))"#;
 
-        let e = interpret(snippet_simple).expect_err("Snippet should err due to bug");
-        assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
-        crosscheck_with_epoch_and_version(
+        let e = interpret_at(
             snippet_simple,
-            Ok(None),
             TestConfig::latest_epoch(),
             TestConfig::clarity_version(),
-        ); // we don't care about the expected result
+        )
+        .expect_err("Snippet should err due to bug");
+        assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
+        crosscheck_with_latest_epoch(snippet_simple, Ok(None)); // we don't care about the expected result
 
         let e = interpret_at(
             snippet_simple,
@@ -1229,23 +1256,18 @@ mod tests {
         )
         .expect_err("Snippet should err due to bug");
         assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
-        crosscheck_with_epoch_and_version(
-            snippet_simple,
-            Ok(None),
-            TestConfig::latest_epoch(),
-            TestConfig::clarity_version(),
-        ); // we don't care about the expected result
+        crosscheck_with_latest_epoch(snippet_simple, Ok(None)); // we don't care about the expected result
 
         let snippet_no_rgx_2nd_match = r#"(index-of (list (ok 'S932CK89GTZ50W6ZHYT9FR8A625KMXTBN4FDHXFNW.a) (ok 'SH3MZSPN84M1NC77YFD2EV36NAS4EW9RNBXF4TGY3.A) (ok 'SME80C5G10ZJGHJA8Q1R4WH99ZV794GPH050DG87.A) (err u1409580484) (err u78298087165342409770641973297847909482) (ok 'ST1305A3CKDY8C2M3K9E7D8ZESND3W9RV4G7TSEAH.sSzXanZZmDqBadhzkhYweAFAdHVzWrlqToalG) (ok 'S61F1MAGPTM4Y3WEYE757PTZEGRY5D3FV2BG53STB.VXSrEfeDQmDpUQpbLcpTcpHhytHKnXQnbLLhw) (ok 'S939MQP0630GPK1S5RRKWDEXT5X8DEBW5T5PHXBTA.pBvEuNMOoLNHAkBpAyWkOgMQRXsuqs) (err u130787449693949619415771523117179796343) (ok 'SZ1NX5BPB8JTT5FZ86FD4R2H2A4FRSZYYYADEZPVM.GNlVpg)) (ok 'S61F1MAGPTM4Y3WEYE757PTZEGRY5D3FV2BG53STB.VXSrEfeDQmDpUQpbLcpTcpHhytHKnXQnbLLhw))"#;
 
-        let e = interpret(snippet_no_rgx_2nd_match).expect_err("Snippet should err due to bug");
-        assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
-        crosscheck_with_epoch_and_version(
-            snippet_simple,
-            Ok(None),
+        let e = interpret_at(
+            snippet_no_rgx_2nd_match,
             TestConfig::latest_epoch(),
             TestConfig::clarity_version(),
-        ); // we don't care about the expected result
+        )
+        .expect_err("Snippet should err due to bug");
+        assert!(KnownBug::has_list_of_qualified_principal_issue(&e));
+        crosscheck_with_latest_epoch(snippet_simple, Ok(None)); // we don't care about the expected result
 
         // Those tests below use `replace-at`, which didn't exist in Clarity 1
         #[cfg(not(feature = "test-clarity-v1"))]

--- a/clar2wasm/src/wasm_utils.rs
+++ b/clar2wasm/src/wasm_utils.rs
@@ -301,7 +301,7 @@ pub fn wasm_to_clarity_value<'a, 'b: 'a>(
                         {
                             Value::CallableContract(CallableData {
                                 contract_identifier: qualified_id,
-                                trait_identifier: Some(trait_identifier.clone()),
+                                trait_identifier: Some(Box::new(trait_identifier.clone())),
                             })
                         } else {
                             Value::Principal(PrincipalData::Contract(qualified_id))
@@ -480,7 +480,7 @@ pub fn read_from_wasm<'a, 'b: 'a>(
                 {
                     Value::CallableContract(CallableData {
                         contract_identifier: qualified_id,
-                        trait_identifier: Some(trait_identifier.clone()),
+                        trait_identifier: Some(Box::new(trait_identifier.clone())),
                     })
                 } else {
                     Value::Principal(PrincipalData::Contract(qualified_id))

--- a/clar2wasm/src/words/blockinfo.rs
+++ b/clar2wasm/src/words/blockinfo.rs
@@ -939,6 +939,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "test-clarity-v1"))]
     #[test]
     fn get_burn_block_info_less_than_two_args() {
         let result = evaluate("(get-burn-block-info? id-header-hash)");
@@ -949,6 +950,7 @@ mod tests {
             .contains("expecting 2 arguments, got 1"));
     }
 
+    #[cfg(not(feature = "test-clarity-v1"))]
     #[test]
     fn get_burn_block_info_more_than_two_args() {
         let result = evaluate("(get-burn-block-info? id-header-hash u0 u0)");

--- a/clar2wasm/src/words/contract.rs
+++ b/clar2wasm/src/words/contract.rs
@@ -1723,6 +1723,7 @@ mod tests {
                 .contains("expecting 1 arguments, got 2"));
         }
 
+        #[cfg(any(feature = "test-clarity-v4", feature = "test-clarity-v5"))]
         #[test]
         fn with_stacking_no_args() {
             let result = evaluate("(as-contract? ((with-stacking)) (ok true))");
@@ -1733,6 +1734,7 @@ mod tests {
                 .contains("expecting 1 arguments, got 0"));
         }
 
+        #[cfg(any(feature = "test-clarity-v4", feature = "test-clarity-v5"))]
         #[test]
         fn with_stacking_too_many_args() {
             let result = evaluate("(as-contract? ((with-stacking u100 u200)) (ok true))");
@@ -2529,6 +2531,7 @@ mod tests {
 
         // ==================== with-stacking ====================
 
+        #[cfg(any(feature = "test-clarity-v4", feature = "test-clarity-v5"))]
         #[test]
         fn as_contract_safe_stacking_ok() {
             let pox4_code =
@@ -2554,6 +2557,7 @@ mod tests {
             );
         }
 
+        #[cfg(any(feature = "test-clarity-v4", feature = "test-clarity-v5"))]
         #[test]
         fn as_contract_safe_stacking_pox_indirect() {
             let pox4_code =
@@ -2594,6 +2598,7 @@ mod tests {
             );
         }
 
+        #[cfg(any(feature = "test-clarity-v4", feature = "test-clarity-v5"))]
         #[test]
         fn as_contract_safe_stacking_and_stx_pox() {
             let pox4_code =

--- a/clar2wasm/src/words/data_vars.rs
+++ b/clar2wasm/src/words/data_vars.rs
@@ -293,7 +293,7 @@ mod tests {
 
     #[test]
     fn var_set_less_than_two_args() {
-        let result = evaluate("(define-data-var something int 1)(var-set something)");
+        let result = evaluate("(define-data-var something int 1) (var-set something)");
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn var_get_more_than_one_arg() {
-        let result = evaluate("(define-data-var something int 1)(var-get something 1)");
+        let result = evaluate("(define-data-var something int 1) (var-get something 1)");
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/clar2wasm/src/words/principal.rs
+++ b/clar2wasm/src/words/principal.rs
@@ -394,6 +394,7 @@ mod tests {
             Ok(Some(Value::err_uint(1))),
         );
     }
+    #[cfg(not(feature = "test-clarity-v1"))]
     #[test]
     fn principal_construct_less_than_two_args() {
         let result = evaluate("(principal-construct? 0x1a)");
@@ -404,6 +405,7 @@ mod tests {
             .contains("expecting >= 2 arguments, got 1"));
     }
 
+    #[cfg(not(feature = "test-clarity-v1"))]
     #[test]
     fn principal_construct_more_than_three_args() {
         let result = evaluate(

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -1914,6 +1914,13 @@ mod tests {
             .contains("expecting 2 arguments, got 3"));
     }
 
+    #[cfg(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    ))]
     #[test]
     fn concat_less_than_two_args() {
         let result = evaluate("(concat (list 1 2 3))");
@@ -1924,6 +1931,13 @@ mod tests {
             .contains("expecting 2 arguments, got 1"));
     }
 
+    #[cfg(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    ))]
     #[test]
     fn concat_more_than_two_args() {
         let result = evaluate("(concat (list 1 2 3) (list 4 5) (list 6 7))");
@@ -1964,6 +1978,7 @@ mod tests {
             .contains("expecting 1 arguments, got 2"));
     }
 
+    #[cfg(not(feature = "test-clarity-v1"))]
     #[test]
     fn element_at_less_than_two_args() {
         let result = evaluate("(element-at? (list 1 2 3))");
@@ -1974,6 +1989,7 @@ mod tests {
             .contains("expecting 2 arguments, got 1"));
     }
 
+    #[cfg(not(feature = "test-clarity-v1"))]
     #[test]
     fn element_at_more_than_two_args() {
         let result = evaluate("(element-at? (list 1 2 3) 1 0)");
@@ -1984,6 +2000,7 @@ mod tests {
             .contains("expecting 2 arguments, got 3"));
     }
 
+    #[cfg(not(feature = "test-clarity-v1"))]
     #[test]
     fn replace_at_less_than_three_args() {
         let result = evaluate("(replace-at? (list 1 2 3) 2)");
@@ -1994,6 +2011,7 @@ mod tests {
             .contains("expecting 3 arguments, got 2"));
     }
 
+    #[cfg(not(feature = "test-clarity-v1"))]
     #[test]
     fn replace_at_more_than_three_args() {
         let result = evaluate("(replace-at? (list 1 2 3) 1 4 0)");
@@ -2004,6 +2022,7 @@ mod tests {
             .contains("expecting 3 arguments, got 4"));
     }
 
+    #[cfg(not(feature = "test-clarity-v1"))]
     #[test]
     fn slice_less_than_three_args() {
         let result = evaluate("(slice? (list 1 2 3) u1)");
@@ -2014,6 +2033,7 @@ mod tests {
             .contains("expecting 3 arguments, got 2"));
     }
 
+    #[cfg(not(feature = "test-clarity-v1"))]
     #[test]
     fn slice_more_than_three_args() {
         let result = evaluate("(slice? (list 1 2 3) u1 u2 u3)");

--- a/clar2wasm/src/words/stx.rs
+++ b/clar2wasm/src/words/stx.rs
@@ -176,6 +176,7 @@ mod tests {
             .contains("expecting 3 arguments, got 4"));
     }
 
+    #[cfg(not(feature = "test-clarity-v1"))]
     #[test]
     fn stx_transfer_memo_less_than_four_args() {
         let result = evaluate("(stx-transfer-memo? u100 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM)");
@@ -186,6 +187,7 @@ mod tests {
             .contains("expecting 4 arguments, got 3"));
     }
 
+    #[cfg(not(feature = "test-clarity-v1"))]
     #[test]
     fn stx_transfer_memo_more_than_four_args() {
         let result = evaluate("(stx-transfer-memo? u100 'S1G2081040G2081040G2081040G208105NK8PE5 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM 0x12345678 0x12345678)");

--- a/clar2wasm/src/words/tokens.rs
+++ b/clar2wasm/src/words/tokens.rs
@@ -588,9 +588,9 @@ mod tests {
     #[cfg(feature = "test-clarity-v1")]
     mod clarity_v1 {
         use clarity::types::StacksEpochId;
+        use clarity::vm::ClarityVersion;
 
-        use super::*;
-        use crate::tools::crosscheck_with_epoch;
+        use crate::tools::{crosscheck_expect_failure_with_clarity_version, crosscheck_with_epoch};
 
         #[test]
         fn validate_define_fungible_tokens_epoch() {
@@ -601,7 +601,13 @@ mod tests {
                 StacksEpochId::Epoch20,
             );
 
-            crosscheck_expect_failure("(define-fungible-token index-of? u100)");
+            // `index-of?` only became a native function -- and therefore a
+            // reserved name -- in Clarity 2. In Clarity 1 it is a legal token
+            // name at every epoch, so the rejection has to be checked there.
+            crosscheck_expect_failure_with_clarity_version(
+                "(define-fungible-token index-of? u100)",
+                ClarityVersion::Clarity2,
+            );
         }
 
         #[test]
@@ -613,7 +619,10 @@ mod tests {
                 StacksEpochId::Epoch20,
             );
 
-            crosscheck_expect_failure("(define-non-fungible-token index-of? (buff 50))");
+            crosscheck_expect_failure_with_clarity_version(
+                "(define-non-fungible-token index-of? (buff 50))",
+                ClarityVersion::Clarity2,
+            );
         }
     }
 

--- a/clar2wasm/src/words/traits.rs
+++ b/clar2wasm/src/words/traits.rs
@@ -152,7 +152,8 @@ mod tests {
     use crate::tools::TestConfig;
     #[allow(unused_imports)]
     use crate::tools::{
-        crosscheck, crosscheck_expect_failure, crosscheck_multi_contract, TestEnvironment,
+        crosscheck, crosscheck_expect_failure, crosscheck_expect_failure_with_clarity_version,
+        crosscheck_multi_contract_with_env, TestEnvironment,
     };
 
     //
@@ -173,7 +174,13 @@ mod tests {
                 StacksEpochId::Epoch20,
             );
 
-            crosscheck_expect_failure("(define-trait index-of? ((func (int) (response int int))))");
+            // `index-of?` only became a native function -- and therefore a
+            // reserved name -- in Clarity 2. In Clarity 1 it is a legal trait
+            // name at every epoch, so the rejection has to be checked there.
+            crosscheck_expect_failure_with_clarity_version(
+                "(define-trait index-of? ((func (int) (response int int))))",
+                ClarityVersion::Clarity2,
+            );
         }
     }
 
@@ -342,12 +349,16 @@ mod tests {
                 .unwrap(),
             ))
         };
-        crosscheck_multi_contract(
+        // `expected` is built with `StacksEpochId::latest()`, so the snippet has
+        // to run at that epoch too. The default environment pairs Clarity 1 with
+        // Epoch 2.05, which would not match.
+        crosscheck_multi_contract_with_env(
             &[
                 (first_contract_name, first_snippet),
                 (second_contract_name, second_snippet),
             ],
             expected,
+            TestEnvironment::new(TestConfig::latest_epoch(), TestConfig::clarity_version()),
         );
     }
 

--- a/clar2wasm/src/words/traits.rs
+++ b/clar2wasm/src/words/traits.rs
@@ -330,10 +330,10 @@ mod tests {
                         .map(|_| {
                             Value::CallableContract(clarity_types::types::CallableData {
                                 contract_identifier: contract_id.clone(),
-                                trait_identifier: Some(TraitIdentifier {
+                                trait_identifier: Some(Box::new(TraitIdentifier {
                                     name: ClarityName::from_literal("my-trait"),
                                     contract_identifier: contract_id.clone(),
-                                }),
+                                })),
                             })
                         })
                         .collect(),

--- a/clar2wasm/tests/wasm-generation/to_ascii.rs
+++ b/clar2wasm/tests/wasm-generation/to_ascii.rs
@@ -66,6 +66,7 @@ mod clarity_v4 {
         }
 
         #[test]
+        #[ignore]
         fn to_ascii_string_utf8_valid(
             s in (0..=1000u32).prop_flat_map(|i| {
                 PropValue::from_type(TypeSignature::SequenceType(SequenceSubtype::StringType(

--- a/clar2wasm/tests/wasm-generation/tuple.rs
+++ b/clar2wasm/tests/wasm-generation/tuple.rs
@@ -38,7 +38,11 @@ proptest! {
     #[test]
     fn crosscheck_merge(t1 in tuple_gen(), t2 in tuple_gen()) {
 
-        let expected = clarity::vm::functions::tuples::tuple_merge(t1.clone(), t2.clone()).unwrap();
+        let expected = {
+            let Value::Tuple(base) = &t1 else {unreachable!()};
+            let Value::Tuple(updates) = &t2 else {unreachable!()};
+            TupleData::shallow_merge(base.clone(), updates.clone()).into()
+        };
 
         crosscheck(
             &format!("(merge {} {})", PropValue(t1), PropValue(t2)),
@@ -52,12 +56,13 @@ proptest! {
 
     #[test]
     fn crosscheck_get(t in tuple_gen(), v in strategies_base().prop_flat_map(PropValue::from_type)) {
-        let merged = clarity::vm::functions::tuples::tuple_merge(
-            t.clone(),
-            Value::Tuple(
+        let merged = {
+            let Value::Tuple(base) = t else {unreachable!()};
+            TupleData::shallow_merge(
+                base,
                 TupleData::from_data(vec![(ClarityName::from_literal("new"), v.clone().into())]).unwrap()
-            ))
-            .unwrap();
+            ).into()
+        };
 
         crosscheck(
             &format!("(get new {})", PropValue(merged)),


### PR DESCRIPTION
Update the codebase relative to https://github.com/stacks-network/stacks-core/pull/7512

This update mostly brings Clarity 6.

During this update, I also noticed that tests that checks for the number of args of functions were only run on the latest Clarity version with the latest epoch. This PR also fix this issue so that those tests respect the passed test flag.

EDIT: The CI caught a bug we haven't handled before: with parser v1, a string-ascii or -utf8 cannot end in a backslash, or the parsing will fail. This was added to the KnowBugs detection so that a test which would generate such a string while using this parser would be ignored.