### PR TITLE
Make `concat` variadic

### DIFF
--- a/clar2wasm/src/duck_type.rs
+++ b/clar2wasm/src/duck_type.rs
@@ -33,20 +33,14 @@ impl WasmGenerator {
             return Ok(());
         }
 
-        let memory_pointer = preallocated_memory.unwrap_or_else(|| {
-            let needed_space = dt_needed_workspace(target_ty);
-            self.ensure_work_space(needed_space);
-            let pointer = self.module.locals.add(ValType::I32);
-            // we reserve the space on the stack frame, so that the duck-typed value cannot be
-            // overwritten by a subsequent duck-typing or stack allocation.
-            builder
-                .global_get(self.stack_pointer)
-                .local_tee(pointer)
-                .i32_const(needed_space as i32)
-                .binop(BinaryOp::I32Add)
-                .global_set(self.stack_pointer);
-            pointer
-        });
+        let memory_pointer = match preallocated_memory {
+            Some(p) => p,
+            None => {
+                let (pointer, _) =
+                    self.create_call_stack_bytes(builder, dt_needed_workspace(target_ty) as i32);
+                pointer
+            }
+        };
 
         let locals = self.create_locals_for_ty(target_ty);
         self.duck_type_stack(builder, og_ty, target_ty, &locals, memory_pointer)?;

--- a/clar2wasm/src/duck_type.rs
+++ b/clar2wasm/src/duck_type.rs
@@ -18,8 +18,9 @@ impl WasmGenerator {
     ///
     /// We can pass the offset to a preallocated memory where the duck-typed value will be written.
     /// This can be necessary to avoid an overwriting of this value if any operation is done right after the duck-typing.
-    /// If the duck-typed value is used immediately after, we can ignore this argument and the duck-typed value will be written
-    /// at the current value of $stack-pointer. The initial value of $stack-pointer will not be reset after the usage of this function.
+    /// If we ignore this argument, the duck-typed value will be written on top of the current call stack frame,
+    /// and $stack-pointer will be moved past it. It is the caller's responsibility to reset $stack-pointer once
+    /// the duck-typed value is not needed anymore.
     pub(crate) fn duck_type(
         &mut self,
         builder: &mut InstrSeqBuilder,
@@ -33,9 +34,17 @@ impl WasmGenerator {
         }
 
         let memory_pointer = preallocated_memory.unwrap_or_else(|| {
-            self.ensure_work_space(dt_needed_workspace(target_ty));
+            let needed_space = dt_needed_workspace(target_ty);
+            self.ensure_work_space(needed_space);
             let pointer = self.module.locals.add(ValType::I32);
-            builder.global_get(self.stack_pointer).local_set(pointer);
+            // we reserve the space on the stack frame, so that the duck-typed value cannot be
+            // overwritten by a subsequent duck-typing or stack allocation.
+            builder
+                .global_get(self.stack_pointer)
+                .local_tee(pointer)
+                .i32_const(needed_space as i32)
+                .binop(BinaryOp::I32Add)
+                .global_set(self.stack_pointer);
             pointer
         });
 

--- a/clar2wasm/src/wasm_generator.rs
+++ b/clar2wasm/src/wasm_generator.rs
@@ -108,8 +108,8 @@ impl Bindings {
         self.0.contains_key(name)
     }
 
-    pub(crate) fn get_locals(&self, name: &ClarityName) -> Option<&[LocalId]> {
-        self.0.get(name).map(|b| b.locals.as_slice())
+    fn get(&self, name: &ClarityName) -> Option<(&[LocalId], &TypeSignature)> {
+        self.0.get(name).map(|b| (b.locals.as_slice(), &b.ty))
     }
 
     pub(crate) fn get_trait_identifier(&self, name: &ClarityName) -> Option<&TraitIdentifier> {
@@ -1794,12 +1794,19 @@ impl WasmGenerator {
         }
 
         // Handle parameters and local bindings
-        let values = self.bindings.get_locals(atom).ok_or_else(|| {
+        let (values, binding_ty) = self.bindings.get(atom).ok_or_else(|| {
             GeneratorError::InternalError(format!("unable to find local for {}", atom.as_str()))
         })?;
+        let binding_ty = binding_ty.clone();
 
         for value in values {
             builder.local_get(*value);
+        }
+
+        // The type-checker doesn't annotate every expression: a binding used as the trait
+        // argument of a `contract-call?` is resolved as a trait reference and never gets a type.
+        if let Some(actual_ty) = self.get_expr_type(expr).cloned() {
+            self.duck_type(builder, &binding_ty, &actual_ty, None)?;
         }
 
         Ok(())

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -2155,6 +2155,18 @@ mod tests {
     }
 
     #[test]
+    fn concat_multiple_duck_typing() {
+        crosscheck(
+            "
+            (let ((a (list (ok (unwrap-panic (as-max-len? 0x99 u60000)))))
+                  (b (list (err u1))))
+              (+ (len (concat a b)) (len (concat b a))))
+            ",
+            Ok(Some(Value::UInt(4))),
+        );
+    }
+
+    #[test]
     fn map_less_than_two_args() {
         let result = evaluate("(map +)");
         assert!(result.is_err());

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -1997,6 +1997,56 @@ mod tests {
         crosscheck(snippet, Ok(Some(expected)));
     }
 
+    #[test]
+    fn concat_2args_with_ducktyping() {
+        let snippet = r#"
+            (let
+                (
+                    (a (list (ok 0x99)))
+                    (b (list (err u42)))
+                )
+                (concat a b)
+            )
+        "#;
+        let expected = Value::cons_list_unsanitized(vec![
+            Value::okay(Value::buff_from_byte(0x99)).unwrap(),
+            Value::err_uint(42),
+        ])
+        .unwrap();
+
+        crosscheck(snippet, Ok(Some(expected)));
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn concat_3args_with_ducktyping() {
+        let snippet = r#"
+            (let
+                (
+                    (a (list (ok 0x99)))
+                    (b (list (err u42)))
+                    (c (list (ok 0xef) (err u1)))
+                )
+                (concat a b c)
+            )
+        "#;
+        let expected = Value::cons_list_unsanitized(vec![
+            Value::okay(Value::buff_from_byte(0x99)).unwrap(),
+            Value::err_uint(42),
+            Value::okay(Value::buff_from_byte(0xef)).unwrap(),
+            Value::err_uint(1),
+        ])
+        .unwrap();
+
+        crosscheck(snippet, Ok(Some(expected)));
+    }
+
     #[cfg(any(
         feature = "test-clarity-v1",
         feature = "test-clarity-v2",
@@ -2012,6 +2062,99 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("expecting 2 arguments, got 3"));
+    }
+
+    #[test]
+    fn map_concat_2args_with_ducktyping() {
+        let snippet = "
+            (define-private (foo
+                (a (list 2 (response (buff 1) uint)))
+                (b (list 3 (response (buff 1) uint)))
+            )
+                (concat a b)
+            )
+
+            (let
+                (
+                    (a (list (ok 0xca)))
+                    (b (list (err u42)))
+                    (c (list (ok 0xfe)))
+                    (d (list (err u24)))
+                    (e (list a c))
+                    (f (list b d))
+                )
+                (map foo e f)
+            )
+        ";
+
+        let expected = Value::cons_list_unsanitized(vec![
+            Value::cons_list_unsanitized(vec![
+                Value::okay(Value::buff_from_byte(0xca)).unwrap(),
+                Value::err_uint(42),
+            ])
+            .unwrap(),
+            Value::cons_list_unsanitized(vec![
+                Value::okay(Value::buff_from_byte(0xfe)).unwrap(),
+                Value::err_uint(24),
+            ])
+            .unwrap(),
+        ])
+        .unwrap();
+
+        crosscheck(snippet, Ok(Some(expected)));
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn map_concat_3args_with_ducktyping() {
+        let snippet = "
+            (define-private (foo
+                (a (list 2 (response (buff 1) uint)))
+                (b (list 3 (response (buff 1) uint)))
+                (c (list 1 (response (buff 1) uint)))
+            )
+                (concat a b c)
+            )
+
+            (let
+                (
+                    (a (list (ok 0xca)))
+                    (b (list (err u42)))
+                    (c (list (ok 0xfe)))
+                    (d (list (err u24)))
+                    (e (list (ok 0xbd)))
+                    (f (list (err u99)))
+                    (ac (list a c))
+                    (bd (list b d))
+                    (ef (list e f))
+                )
+                (map foo ac bd ef)
+            )
+        ";
+
+        let expected = Value::cons_list_unsanitized(vec![
+            Value::cons_list_unsanitized(vec![
+                Value::okay(Value::buff_from_byte(0xca)).unwrap(),
+                Value::err_uint(42),
+                Value::okay(Value::buff_from_byte(0xbd)).unwrap(),
+            ])
+            .unwrap(),
+            Value::cons_list_unsanitized(vec![
+                Value::okay(Value::buff_from_byte(0xfe)).unwrap(),
+                Value::err_uint(24),
+                Value::err_uint(99),
+            ])
+            .unwrap(),
+        ])
+        .unwrap();
+
+        crosscheck(snippet, Ok(Some(expected)));
     }
 
     #[test]

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -565,7 +565,7 @@ impl ComplexWord for Concat {
         generator: &mut crate::wasm_generator::WasmGenerator,
         builder: &mut walrus::InstrSeqBuilder,
         expr: &SymbolicExpression,
-        args: &[clarity::vm::SymbolicExpression],
+        args: &[SymbolicExpression],
     ) -> Result<(), GeneratorError> {
         check_args!(
             generator,

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -3,7 +3,6 @@ use clarity::vm::types::{
     FixedFunction, FunctionType, ListTypeData, SequenceSubtype, StringSubtype, TypeSignature,
 };
 use clarity::vm::{ClarityName, SymbolicExpression};
-use clarity_types::ClarityVersion::Clarity5;
 use walrus::ir::{self, BinaryOp, IfElse, InstrSeqType, Loop, UnaryOp};
 use walrus::ValType;
 
@@ -568,17 +567,21 @@ impl ComplexWord for Concat {
         expr: &SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), GeneratorError> {
-        if generator.contract_analysis.clarity_version <= Clarity5 {
-            check_args!(generator, builder, 2, args.len(), ArgumentCountCheck::Exact);
-        } else {
-            check_args!(
-                generator,
-                builder,
-                2,
-                args.len(),
+        check_args!(
+            generator,
+            builder,
+            2,
+            args.len(),
+            if !generator
+                .contract_analysis
+                .clarity_version
+                .supports_variadic_concat()
+            {
+                ArgumentCountCheck::Exact
+            } else {
                 ArgumentCountCheck::AtLeast
-            );
-        }
+            }
+        );
 
         let memory = generator.get_memory()?;
 
@@ -1896,7 +1899,7 @@ impl ComplexWord for Slice {
 mod tests {
     use clarity::vm::Value;
 
-    use crate::tools::{crosscheck, crosscheck_compare_only, evaluate, interpret};
+    use crate::tools::{crosscheck, crosscheck_compare_only, evaluate, interpret, TestConfig};
 
     #[test]
     fn fold_less_than_three_args() {
@@ -1961,13 +1964,7 @@ mod tests {
     #[test]
     fn concat_less_than_two_args() {
         let result = evaluate("(concat (list 1 2 3))");
-        let expected_err = if cfg!(any(
-            feature = "test-clarity-v1",
-            feature = "test-clarity-v2",
-            feature = "test-clarity-v3",
-            feature = "test-clarity-v4",
-            feature = "test-clarity-v5"
-        )) {
+        let expected_err = if !TestConfig::clarity_version().supports_variadic_concat() {
             "expecting 2 arguments, got 1"
         } else {
             "expecting >= 2 arguments, got 1"

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -1976,6 +1976,27 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains(expected_err));
     }
 
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn concat_3args() {
+        let snippet = "(concat (list (ok true)) (list (err u1)) (list (ok true) (err u42)))";
+        let expected = Value::cons_list_unsanitized(vec![
+            Value::okay_true(),
+            Value::err_uint(1),
+            Value::okay_true(),
+            Value::err_uint(42),
+        ])
+        .unwrap();
+
+        crosscheck(snippet, Ok(Some(expected)));
+    }
+
     #[cfg(any(
         feature = "test-clarity-v1",
         feature = "test-clarity-v2",

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -1961,11 +1961,19 @@ mod tests {
     #[test]
     fn concat_less_than_two_args() {
         let result = evaluate("(concat (list 1 2 3))");
+        let expected_err = if cfg!(any(
+            feature = "test-clarity-v1",
+            feature = "test-clarity-v2",
+            feature = "test-clarity-v3",
+            feature = "test-clarity-v4",
+            feature = "test-clarity-v5"
+        )) {
+            "expecting 2 arguments, got 1"
+        } else {
+            "expecting >= 2 arguments, got 1"
+        };
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("expecting 2 arguments, got 1"));
+        assert!(result.unwrap_err().to_string().contains(expected_err));
     }
 
     #[cfg(any(

--- a/clar2wasm/src/words/sequences.rs
+++ b/clar2wasm/src/words/sequences.rs
@@ -3,6 +3,7 @@ use clarity::vm::types::{
     FixedFunction, FunctionType, ListTypeData, SequenceSubtype, StringSubtype, TypeSignature,
 };
 use clarity::vm::{ClarityName, SymbolicExpression};
+use clarity_types::ClarityVersion::Clarity5;
 use walrus::ir::{self, BinaryOp, IfElse, InstrSeqType, Loop, UnaryOp};
 use walrus::ValType;
 
@@ -567,7 +568,17 @@ impl ComplexWord for Concat {
         expr: &SymbolicExpression,
         args: &[clarity::vm::SymbolicExpression],
     ) -> Result<(), GeneratorError> {
-        check_args!(generator, builder, 2, args.len(), ArgumentCountCheck::Exact);
+        if generator.contract_analysis.clarity_version <= Clarity5 {
+            check_args!(generator, builder, 2, args.len(), ArgumentCountCheck::Exact);
+        } else {
+            check_args!(
+                generator,
+                builder,
+                2,
+                args.len(),
+                ArgumentCountCheck::AtLeast
+            );
+        }
 
         let memory = generator.get_memory()?;
 
@@ -578,54 +589,87 @@ impl ComplexWord for Concat {
             .clone();
         let (offset, _) = generator.create_call_stack_local(builder, &ty, false, true);
 
+        // set the correct type for all the arguments if we are dealing with lists
+        if let TypeSignature::SequenceType(SequenceSubtype::ListType(expr_ltd)) = &ty {
+            for arg in args {
+                let arg_type = generator.get_expr_type(arg).ok_or_else(|| {
+                    GeneratorError::TypeError("concat argument must be typed".to_owned())
+                })?;
+                let arg_len = match arg_type {
+                    TypeSignature::SequenceType(SequenceSubtype::ListType(arg_ltd)) => {
+                        arg_ltd.get_max_len()
+                    }
+                    t => {
+                        return Err(GeneratorError::TypeError(format!(
+                            "mismatched type for a concat argument: expected a list, got {t}"
+                        )))
+                    }
+                };
+                generator.set_expr_type(
+                    arg,
+                    // since we are building a type which will necessarily be shorter than the expression type,
+                    // and the expression type was validated by the type checker, this operation cannot fail.
+                    #[allow(clippy::unwrap_used)]
+                    TypeSignature::list_of(expr_ltd.get_list_item_type().clone(), arg_len).unwrap(),
+                )?;
+            }
+        }
+
+        let [fst_arg, rest_args @ ..] = args else {
+            return Err(GeneratorError::InternalError(
+                "concat should have at least 2 arguments".to_owned(),
+            ));
+        };
+
+        // this will contain the result size
+        let size = generator.borrow_local(ValType::I32);
+
+        // handling the first argument:
+        // copy destination
         builder.local_get(offset);
 
-        // Traverse the lhs, leaving it on the data stack (offset, size)
-        let lhs = args.get_expr(0)?;
-        // WORKAROUND: typechecker issue for lists
-        generator.set_expr_type(lhs, ty.clone())?;
-        generator.traverse_expr(builder, lhs)?;
+        // traverse the first argument, leaves on the stack (offset, size) which are the
+        // correct arguments for the memory copy operation right after.
+        generator.traverse_expr(builder, fst_arg)?;
 
-        // Save the length of the lhs
-        let lhs_length = generator.module.locals.add(ValType::I32);
-        builder.local_tee(lhs_length);
+        // we save the size
+        builder.local_tee(*size);
 
-        // Copy the lhs to the new sequence
+        // and finally, the copy of the first argument
         builder.memory_copy(memory, memory);
 
-        // Load the adjusted destination offset
-        builder
-            .local_get(offset)
-            .local_get(lhs_length)
-            .binop(BinaryOp::I32Add);
+        // here we can traverse and copy the rest of the arguments
+        for arg in rest_args {
+            let tmp = generator.borrow_local(ValType::I32);
 
-        // Traverse the rhs, leaving it on the data stack (offset, size)
-        let rhs = args.get_expr(1)?;
-        // WORKAROUND: typechecker issue for lists
-        generator.set_expr_type(rhs, ty.clone())?;
-        generator.traverse_expr(builder, rhs)?;
+            // copy destination is the result offset + the number of bytes already copied
+            builder
+                .local_get(offset)
+                .local_get(*size)
+                .binop(BinaryOp::I32Add);
 
-        // Save the length of the rhs
-        let rhs_length = generator.module.locals.add(ValType::I32);
-        builder.local_tee(rhs_length);
+            // traverse the argument, leaving on the stack (offset, size)
+            generator.traverse_expr(builder, arg)?;
 
-        // Copy the rhs to the new sequence
-        builder.memory_copy(memory, memory);
+            // we keep the argument size on the stack, but use it to update the result size
+            builder
+                .local_tee(*tmp)
+                .local_get(*size)
+                .binop(BinaryOp::I32Add)
+                .local_set(*size);
+            builder.local_get(*tmp);
 
-        // Load the offset of the new sequence
-        builder.local_get(offset);
+            // Copy the argument to the new sequence
+            builder.memory_copy(memory, memory);
+        }
 
-        // Total size = lhs_length + rhs_length
-        builder
-            .local_get(lhs_length)
-            .local_get(rhs_length)
-            .binop(BinaryOp::I32Add);
-
+        // TODO: check if this is still correct for Clarity 6+
         // we charge after the operation since that's the only time we have the
         // length of the resulting list
-        let length = generator.module.locals.add(ValType::I32);
-        builder.local_tee(length);
-        self.charge(generator, builder, length)?;
+        self.charge(generator, builder, *size)?;
+
+        // Put the result sequence on the stack
+        builder.local_get(offset).local_get(*size);
 
         Ok(())
     }
@@ -1914,13 +1958,6 @@ mod tests {
             .contains("expecting 2 arguments, got 3"));
     }
 
-    #[cfg(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    ))]
     #[test]
     fn concat_less_than_two_args() {
         let result = evaluate("(concat (list 1 2 3))");

--- a/clar2wasm/tests/wasm-generation/sequences.rs
+++ b/clar2wasm/tests/wasm-generation/sequences.rs
@@ -79,6 +79,44 @@ proptest! {
 
         crosscheck(&snippet, Ok(Some(expected)));
     }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn concat_variad_crosscheck(
+        seqs in prop_sequence_type(10).prop_flat_map(|ty| proptest::collection::vec(PropValue::from_type(ty), 2..10))
+            .prop_filter("skip large values", |seqs| seqs.iter().map(|s| s.inner().size().unwrap()).sum::<u32>() <= MAX_VALUE_SIZE)
+    ) {
+        let [head, tail @ ..] = &seqs[..] else {
+            unreachable!()
+        };
+        let snippet = format!(
+            "(concat {head}{})",
+            tail.iter().map(|s| format!(" {s}")).collect::<String>()
+        );
+
+        let expected = Value::Sequence(
+            seqs.into_iter()
+                .map(|s| {
+                    let Value::Sequence(data) = s.into() else {
+                        unreachable!()
+                    };
+                    data
+                })
+                .reduce(|mut a, b| {
+                    a.concat(&clarity::types::StacksEpochId::latest(), b).unwrap();
+                    a
+                })
+                .unwrap(),
+        );
+
+        crosscheck(&snippet, Ok(Some(expected)));
+    }
 }
 
 proptest! {
@@ -647,4 +685,8 @@ mod clarity_v2_v3 {
             crosscheck(&snippet, Ok(Some(expected)));
         }
     }
+}
+
+pub fn prop_sequence_type(size: usize) -> impl Strategy<Value = TypeSignature> {
+    PropValue::any_sequence(size).prop_map(|s| TypeSignature::type_of(s.inner()).unwrap())
 }


### PR DESCRIPTION
Clarity 6 introduces  a variadic `concat`.

This rewrites the word traversal so that it can handle the original 2 arguments or any number of them.
It also adds a prop test which generates concats with up to 10 arguments.

It also fixes a bug in the loading of let-bindings, which were not duck-typed when needed (Thank you @brice-stacks for [finding this](https://github.com/stx-labs/clarity-wasm/pull/831#discussion_r3831288199))

This PR also found a bug in the duck-typing, where some memory used for duck-typed arguments in a `map` expression could overwrite each other. This especially can happen with `concat` since it uses it's arguments directly in the result.

Closes #833 