### PR TITLE
fix: allow use of locally defined trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#db5f34254a626f4db1c2a4586ba8cd96b94ff471"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#13bd589dfde3bb9463949693bbd25bb9e28054e2"
 dependencies = [
  "clarity-types",
  "hashbrown 0.15.5",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "clarity-types"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#db5f34254a626f4db1c2a4586ba8cd96b94ff471"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#13bd589dfde3bb9463949693bbd25bb9e28054e2"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#db5f34254a626f4db1c2a4586ba8cd96b94ff471"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#13bd589dfde3bb9463949693bbd25bb9e28054e2"
 dependencies = [
  "chrono",
  "curve25519-dalek",

--- a/clar2wasm/src/lib.rs
+++ b/clar2wasm/src/lib.rs
@@ -181,14 +181,14 @@ pub fn compile_contract(contract_analysis: ContractAnalysis) -> Result<Module, G
 }
 
 mod utils {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     use clarity::types::StacksEpochId;
     use clarity::vm::analysis::{AnalysisDatabase, ContractAnalysis};
     use clarity::vm::ast::ContractAST;
     use clarity::vm::errors::StaticCheckError;
-    use clarity::vm::types::signatures::FunctionReturnsSignature;
-    use clarity::vm::types::{FixedFunction, FunctionType};
+    use clarity::vm::types::signatures::{FunctionReturnsSignature, FunctionSignature};
+    use clarity::vm::types::{FixedFunction, FunctionType, QualifiedContractIdentifier};
     use clarity::vm::SymbolicExpression;
     use clarity_types::representations::TraitDefinition;
     use clarity_types::types::PrincipalData::Contract;
@@ -256,13 +256,19 @@ mod utils {
     ///
     /// `trait_args` maps an in-scope function argument name to the local alias of
     /// the trait it was declared with (e.g. `tt` -> `printer`), so that dynamic
-    /// calls through a trait reference can be resolved too.
-    /// See issue #819
+    /// calls through a trait reference can be resolved too. See issue #819.
+    ///
+    /// `contract_identifier` and `defined_traits` describe the contract currently
+    /// being compiled. A trait it defines itself is not in the analysis database
+    /// yet, so it has to be resolved from the in-progress analysis instead.
+    #[allow(clippy::too_many_arguments)]
     fn add_type_annotation_for_contracts(
         ast: &ContractAST,
         expr: &SymbolicExpression,
         analysis_db: &mut AnalysisDatabase,
         epoch: StacksEpochId,
+        contract_identifier: &QualifiedContractIdentifier,
+        defined_traits: &BTreeMap<ClarityName, BTreeMap<ClarityName, FunctionSignature>>,
         trait_args: &mut HashMap<ClarityName, ClarityName>,
     ) -> Result<Vec<(SymbolicExpression, TypeSignature)>, StaticCheckError> {
         let Some(list @ [first, rest @ ..]) = expr.match_list() else {
@@ -303,11 +309,18 @@ mod utils {
                     TraitDefinition::Imported(trait_id) | TraitDefinition::Defined(trait_id),
                 ) = ast.get_referenced_trait(alias)
                 {
-                    if let Some(trait_signature) = analysis_db.get_defined_trait(
-                        &trait_id.contract_identifier,
-                        &trait_id.name,
-                        &epoch,
-                    )? {
+                    // A locally defined trait is not in the analysis database yet,
+                    // so take it from the in-progress analysis instead.
+                    let trait_signature = if trait_id.contract_identifier == *contract_identifier {
+                        defined_traits.get(&trait_id.name).cloned()
+                    } else {
+                        analysis_db.get_defined_trait(
+                            &trait_id.contract_identifier,
+                            &trait_id.name,
+                            &epoch,
+                        )?
+                    };
+                    if let Some(trait_signature) = trait_signature {
                         if let Some(function_signature) = trait_signature.get(function_name) {
                             return Ok(call_args
                                 .iter()
@@ -344,7 +357,15 @@ mod utils {
 
         list.iter()
             .map(|child| {
-                add_type_annotation_for_contracts(ast, child, analysis_db, epoch, trait_args)
+                add_type_annotation_for_contracts(
+                    ast,
+                    child,
+                    analysis_db,
+                    epoch,
+                    contract_identifier,
+                    defined_traits,
+                    trait_args,
+                )
             })
             .collect::<Result<Vec<_>, _>>()
             .map(|a| a.into_iter().flatten().collect())
@@ -369,6 +390,8 @@ mod utils {
                         expr,
                         analysis_db,
                         epoch,
+                        &contract_analysis.contract_identifier,
+                        &contract_analysis.defined_traits,
                         &mut trait_args,
                     )
                 })

--- a/clar2wasm/src/words/contract.rs
+++ b/clar2wasm/src/words/contract.rs
@@ -1099,6 +1099,40 @@ mod tests {
         assert_eq!(val.unwrap(), Value::okay(Value::UInt(42)).unwrap());
     }
 
+    /// Regression test: dynamic dispatch through a trait defined in the
+    /// calling contract itself (`define-trait`, no `use-trait` import) used
+    /// to fail codegen with "Usage of an unimported trait", because only
+    /// `use-trait` registered traits in `used_traits`.
+    #[test]
+    fn dynamic_with_locally_defined_trait() {
+        let mut env = TestEnvironment::default();
+        env.init_contract_with_snippet(
+            "contract-callee",
+            r#"
+(define-public (no-args)
+    (ok u42)
+)
+            "#,
+        )
+        .expect("Failed to init contract.");
+        env.init_contract_with_snippet(
+            "contract-caller",
+            r#"
+(define-trait test-trait ((no-args () (response uint uint))))
+(define-public (call-it (t <test-trait>))
+    (contract-call? t no-args)
+)
+            "#,
+        )
+        .expect("Failed to init contract.");
+
+        let val = env
+            .evaluate("(contract-call? .contract-caller call-it .contract-callee)")
+            .expect("Failed to call contract.");
+
+        assert_eq!(val.unwrap(), Value::okay(Value::UInt(42)).unwrap());
+    }
+
     #[test]
     fn dynamic_one_simple_arg() {
         let mut env = TestEnvironment::default();

--- a/clar2wasm/src/words/contract.rs
+++ b/clar2wasm/src/words/contract.rs
@@ -1102,7 +1102,9 @@ mod tests {
     /// Regression test: dynamic dispatch through a trait defined in the
     /// calling contract itself (`define-trait`, no `use-trait` import) used
     /// to fail codegen with "Usage of an unimported trait", because only
-    /// `use-trait` registered traits in `used_traits`.
+    /// `use-trait` registered traits in `used_traits`. In Clarity 1 it then
+    /// failed analysis, because the trait was looked up in the analysis
+    /// database, where the contract being compiled is not stored yet.
     #[test]
     fn dynamic_with_locally_defined_trait() {
         let mut env = TestEnvironment::default();
@@ -2410,7 +2412,7 @@ mod tests {
                 (contract-call? .callee mint-nft u1)
                 (let ((result (contract-call? .callee transfer-token u1)))
                     {
-                        result: result, 
+                        result: result,
                         owner: (contract-call? .callee get-nft-owner u1)
                     }
                 )

--- a/clar2wasm/src/words/traits.rs
+++ b/clar2wasm/src/words/traits.rs
@@ -1,3 +1,4 @@
+use clarity::vm::types::TraitIdentifier;
 use clarity::vm::{ClarityName, SymbolicExpression, SymbolicExpressionType};
 
 use super::{ComplexWord, Word};
@@ -31,6 +32,16 @@ impl ComplexWord for DefineTrait {
                 "Name already used {name:?}"
             )));
         }
+
+        // A locally-defined trait can be used for dynamic dispatch in this
+        // contract without a `use-trait` import, so register it in
+        // `used_traits` like an imported one.
+        let trait_id = TraitIdentifier {
+            name: name.clone(),
+            contract_identifier: generator.contract_analysis.contract_identifier.clone(),
+        };
+        let offset_len = generator.add_trait_identifier(&trait_id)?;
+        generator.used_traits.insert(trait_id, offset_len);
 
         // Store the identifier as a string literal in the memory
         let (name_offset, name_length) = generator.add_string_literal(name)?;

--- a/clar2wasm/tests/standard/unit_tests.rs
+++ b/clar2wasm/tests/standard/unit_tests.rs
@@ -2254,8 +2254,11 @@ fn sha256_prerequisite() {
         .read(&mut store, 0, &mut buffer)
         .expect("Could not read initial hash from memory");
     let buffer: Vec<_> = buffer
-        .chunks_exact(4)
-        .map(|i| u32::from_le_bytes(i.try_into().unwrap()))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .copied()
+        .map(u32::from_le_bytes)
         .collect();
     assert_eq!(
         buffer,
@@ -2271,8 +2274,11 @@ fn sha256_prerequisite() {
         .read(&mut store, 32, &mut buffer)
         .expect("could not read K values from memory");
     let buffer: Vec<_> = buffer
-        .chunks_exact(4)
-        .map(|i| i32::from_le_bytes(i.try_into().unwrap()))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .copied()
+        .map(i32::from_le_bytes)
         .collect();
     assert_eq!(
         buffer,
@@ -2566,8 +2572,11 @@ fn hash160_prerequisite() {
         .read(&mut store, 608, &mut buffer)
         .expect("Could not read initial hash from memory");
     let buffer: Vec<_> = buffer
-        .chunks_exact(4)
-        .map(|i| u32::from_le_bytes(i.try_into().unwrap()))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .copied()
+        .map(u32::from_le_bytes)
         .collect();
     assert_eq!(buffer, [0, 0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xa953fd4e]);
 
@@ -2577,8 +2586,11 @@ fn hash160_prerequisite() {
         .read(&mut store, 628, &mut buffer)
         .expect("Could not read initial hash from memory");
     let buffer: Vec<_> = buffer
-        .chunks_exact(4)
-        .map(|i| u32::from_le_bytes(i.try_into().unwrap()))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .copied()
+        .map(u32::from_le_bytes)
         .collect();
     assert_eq!(buffer, [0x50a28be6, 0x5c4dd124, 0x6d703ef3, 0x7a6d76e9, 0]);
 }
@@ -3773,8 +3785,11 @@ fn uint_to_utf8() {
             .expect("could not read string answer from memory");
 
         let buffer: Option<String> = buffer
-            .chunks_exact(4)
-            .map(|c| u32::from_be_bytes(c.try_into().unwrap()))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .copied()
+            .map(u32::from_be_bytes)
             .map(char::from_u32)
             .collect();
 
@@ -3840,8 +3855,11 @@ fn int_to_utf8() {
             .expect("could not read string answer from memory");
 
         let buffer: Option<String> = buffer
-            .chunks_exact(4)
-            .map(|c| u32::from_be_bytes(c.try_into().unwrap()))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .copied()
+            .map(u32::from_be_bytes)
             .map(char::from_u32)
             .collect();
 
@@ -4059,8 +4077,11 @@ fn utf8_to_string_utf8_valid() {
             .read(&mut store, 3000, &mut buffer)
             .expect("Could not read from memory");
         let buffer: Vec<_> = buffer
-            .chunks_exact(4)
-            .map(|c| u32::from_be_bytes(c.try_into().unwrap()))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .copied()
+            .map(u32::from_be_bytes)
             .collect();
         assert_eq!(buffer, unicodes_result);
     };


### PR DESCRIPTION
When a contract contains a `define-trait`, that trait can be used within that contract, same as if there was a `use-trait`.