### PR TITLE
Fix contract-call memory allocation for arguments

### DIFF
--- a/clar2wasm/src/tools.rs
+++ b/clar2wasm/src/tools.rs
@@ -1106,7 +1106,48 @@ pub fn as_oom_check_snippet(
     epoch: StacksEpochId,
     version: ClarityVersion,
 ) -> String {
-    let compiled_module = Datastore::new()
+    inner_as_oom_check_snippet(snippet, &[], args_types, epoch, version)
+}
+
+#[allow(clippy::expect_used)]
+fn inner_as_oom_check_snippet(
+    snippet: &str,
+    contracts: &[(ContractName, &str)],
+    args_types: &[TypeSignature],
+    epoch: StacksEpochId,
+    version: ClarityVersion,
+) -> String {
+    let mut datastore = Datastore::new();
+
+    for (name, contract) in contracts {
+        let contract_id =
+            QualifiedContractIdentifier::new(StandardPrincipalData::transient(), name.clone());
+        let contract_analysis = datastore
+            .as_analysis_db()
+            .execute(|analysis_db| {
+                compile(
+                    contract,
+                    &contract_id,
+                    LimitedCostTracker::new_free(),
+                    version,
+                    epoch,
+                    analysis_db,
+                    false,
+                )
+                .map_err(|e| {
+                    StaticCheckErrorKind::Unreachable(format!("Compilation failure {e:?}"))
+                })
+            })
+            .expect("Could not compile contract")
+            .contract_analysis;
+
+        datastore
+            .as_analysis_db()
+            .execute(|analysis_db| analysis_db.insert_contract(&contract_id, &contract_analysis))
+            .expect("Could not insert contract analysis");
+    }
+
+    let compiled_module = datastore
         .as_analysis_db()
         .execute(|analysis_db| {
             compile(
@@ -1197,6 +1238,32 @@ pub fn crosscheck_oom_with_non_literal_args_compare_only(
 
 pub fn crosscheck_oom(snippet: &str, expected: Result<Option<Value>, VmExecutionError>) {
     crosscheck_oom_with_non_literal_args(snippet, &[], expected)
+}
+
+/// Same as [`crosscheck_multi_contract`], but the last contract is padded to
+/// fill its memory, so that it will run out of memory if it needs more space
+/// than what was allocated for it.
+#[allow(clippy::expect_used)]
+pub fn crosscheck_oom_multi_contract(
+    contracts: &[(ContractName, &str)],
+    expected: Result<Option<Value>, VmExecutionError>,
+) {
+    let ((name, snippet), previous_contracts) = contracts
+        .split_last()
+        .expect("There should be at least one contract");
+
+    let padded_snippet = inner_as_oom_check_snippet(
+        snippet,
+        previous_contracts,
+        &[],
+        TestConfig::latest_epoch(),
+        TestConfig::clarity_version(),
+    );
+
+    let mut contracts = previous_contracts.to_vec();
+    contracts.push((name.clone(), &padded_snippet));
+
+    crosscheck_multi_contract(&contracts, expected);
 }
 
 pub fn crosscheck_oom_compare_only_with_epoch_and_version(

--- a/clar2wasm/src/words/contract.rs
+++ b/clar2wasm/src/words/contract.rs
@@ -5,7 +5,7 @@ use clarity::vm::clarity_wasm::get_type_size;
 use clarity::vm::types::signatures::CallableSubtype;
 use clarity::vm::types::{PrincipalData, TypeSignature};
 use clarity::vm::{ClarityName, SymbolicExpression, SymbolicExpressionType, Value};
-use walrus::ir::{BinaryOp, Block, InstrSeqType};
+use walrus::ir::{Block, InstrSeqType};
 use walrus::{LocalId, ValType};
 
 use super::{ComplexWord, Word};
@@ -796,14 +796,8 @@ impl ComplexWord for ContractCall {
             .i32_const(fn_length as i32);
 
         // Write the arguments to the call stack, to be read by the host
-        let arg_offset = generator.module.locals.add(ValType::I32);
         let total_args_size = args_ty.iter().map(get_type_size).sum();
-        builder
-            .global_get(generator.stack_pointer)
-            .local_tee(arg_offset)
-            .i32_const(total_args_size)
-            .binop(BinaryOp::I32Add)
-            .global_set(generator.stack_pointer);
+        let (arg_offset, _) = generator.create_call_stack_bytes(builder, total_args_size);
 
         let mut arg_length = 0;
         for (arg, arg_ty) in args.iter().zip(args_ty) {

--- a/clar2wasm/tests/oom-checker/unit_tests.rs
+++ b/clar2wasm/tests/oom-checker/unit_tests.rs
@@ -1,6 +1,6 @@
 use clar2wasm::tools::{
-    as_oom_check_snippet, crosscheck_multi_contract, crosscheck_oom, crosscheck_oom_with_env,
-    crosscheck_oom_with_non_literal_args, TestConfig, TestEnvironment,
+    as_oom_check_snippet, crosscheck_multi_contract, crosscheck_oom, crosscheck_oom_multi_contract,
+    crosscheck_oom_with_env, crosscheck_oom_with_non_literal_args, TestConfig, TestEnvironment,
 };
 use clarity::vm::types::{PrincipalData, TypeSignature};
 use clarity::vm::{ClarityName, ContractName, Value};
@@ -315,6 +315,36 @@ fn contract_call_with_workspace_oom() {
     .unwrap();
 
     crosscheck_multi_contract(
+        &[
+            (ContractName::from_literal("callee"), &callee),
+            (ContractName::from_literal("caller"), caller),
+        ],
+        Ok(Some(expected)),
+    );
+}
+
+#[test]
+fn contract_call_args_space_oom() {
+    // The result slot for `(response (buff RESULT_LEN) NoType)` is
+    // `get_type_size` (16) + `get_type_in_memory_size` (RESULT_LEN + 16), so
+    // this makes it exactly one Wasm page: after padding, the caller has room
+    // for the result and nothing more. The buffer is returned at full length so
+    // that the write really reaches the last byte of the slot.
+    const RESULT_LEN: usize = 65536 - 32;
+
+    let callee = format!(
+        r#"
+            (define-public (foo (a uint) (b uint))
+                (ok 0x{})
+            )
+        "#,
+        "00".repeat(RESULT_LEN)
+    );
+    let caller = "(contract-call? .callee foo u1 u2)";
+
+    let expected = Value::okay(Value::buff_from(vec![0; RESULT_LEN]).unwrap()).unwrap();
+
+    crosscheck_oom_multi_contract(
         &[
             (ContractName::from_literal("callee"), &callee),
             (ContractName::from_literal("caller"), caller),


### PR DESCRIPTION
The current traversal for `contract-call` was allocating space for the function arguments without extending the frame size at compile time. This could lead to OOM issues.

This fixes the behavior, and add tests to ensure this bug cannot happen again.
For this test, I added a new testing helper `crosscheck_oom_multi_contract`.