### PR TITLE
feat: add bitcoin tx output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#e7b0d5772c5861fabf864e21fa5caa258a057bf1"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#a331d45b03a38ab838921e0594eefdc05fd3e45d"
 dependencies = [
  "clarity-types",
  "hashbrown 0.15.5",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "clarity-types"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#e7b0d5772c5861fabf864e21fa5caa258a057bf1"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#a331d45b03a38ab838921e0594eefdc05fd3e45d"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#e7b0d5772c5861fabf864e21fa5caa258a057bf1"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#a331d45b03a38ab838921e0594eefdc05fd3e45d"
 dependencies = [
  "chrono",
  "curve25519-dalek",

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -11,7 +11,9 @@ use clarity::vm::errors::{
     RuntimeCheckErrorKind, RuntimeError, StaticCheckErrorKind, VmExecutionError, VmInternalError,
     WasmError,
 };
-use clarity::vm::functions::bitcoin::{native_verify_merkle_proof, VERIFY_MERKLE_PROOF_MAX_DEPTH};
+use clarity::vm::functions::bitcoin::{
+    native_get_bitcoin_tx_output, native_verify_merkle_proof, VERIFY_MERKLE_PROOF_MAX_DEPTH,
+};
 use clarity::vm::functions::crypto::{pubkey_to_address_v1, pubkey_to_address_v2};
 use clarity::vm::functions::post_conditions::{
     check_allowances, Allowance, FtAllowance, NftAllowance, StackingAllowance, StxAllowance,
@@ -174,6 +176,7 @@ pub fn link_host_functions(
     link_secp256r1_verify_double_hash_fn(linker)?;
     link_secp256r1_verify_simple_hash_fn(linker)?;
     link_verify_merkle_proof_fn(linker)?;
+    link_get_bitcoin_tx_output_fn(linker)?;
     link_ed25519_verify_fn(linker)?;
     link_principal_of_fn(linker)?;
     link_save_constant_fn(linker)?;
@@ -6187,6 +6190,80 @@ fn link_verify_merkle_proof_fn(
         })
 }
 
+/// The return type of `get-bitcoin-tx-output?`:
+/// `(response { script: (buff 1024), amount: uint, txid: (buff 32) } uint)`.
+fn get_bitcoin_tx_output_result_type() -> Result<TypeSignature, VmExecutionError> {
+    let ok_ty: TypeSignature = TupleTypeSignature::try_from(vec![
+        (
+            ClarityName::from_literal("script"),
+            TypeSignature::BUFFER_1024.clone(),
+        ),
+        (ClarityName::from_literal("amount"), TypeSignature::UIntType),
+        (
+            ClarityName::from_literal("txid"),
+            TypeSignature::BUFFER_32.clone(),
+        ),
+    ])?
+    .into();
+    Ok(TypeSignature::new_response(ok_ty, TypeSignature::UIntType)?)
+}
+
+/// Link host interface function, `get_bitcoin_tx_output`, into the Wasm module.
+/// This function is called for the Clarity expression, `get-bitcoin-tx-output?`.
+fn link_get_bitcoin_tx_output_fn(
+    linker: &mut Linker<ClarityWasmContext>,
+) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "get_bitcoin_tx_output",
+            |mut caller: Caller<'_, ClarityWasmContext>,
+             tx_offset: i32,
+             tx_length: i32,
+             vout_lo: i64,
+             vout_hi: i64,
+             return_offset: i32,
+             _return_length: i32| {
+                // Get the memory from the caller
+                let memory = caller
+                    .get_export("memory")
+                    .and_then(|export| export.into_memory())
+                    .ok_or(VmExecutionError::Wasm(WasmError::MemoryNotFound))?;
+
+                let ret_ty = get_bitcoin_tx_output_result_type()?;
+                let repr_size = get_type_size(&ret_ty);
+
+                let tx_bytes = read_bytes_from_wasm(memory, &mut caller, tx_offset, tx_length)?;
+
+                // `vout` is a Clarity `uint`, passed as a low/high `i64` pair
+                let vout = ((vout_hi as u64 as u128) << 64) | (vout_lo as u64 as u128);
+
+                let result =
+                    native_get_bitcoin_tx_output(Value::buff_from(tx_bytes)?, Value::UInt(vout))?;
+
+                // Write the result to the return buffer
+                write_to_wasm(
+                    caller,
+                    memory,
+                    &ret_ty,
+                    return_offset,
+                    return_offset + repr_size,
+                    &result,
+                    true,
+                )?;
+
+                Ok(())
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "get_bitcoin_tx_output".to_string(),
+                e,
+            ))
+        })
+}
+
 /// Link host interface function, `ed25519_verify`, into the Wasm module.
 /// This function is called for the Clarity expression, `ed25519-verify`.
 fn link_ed25519_verify_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), VmExecutionError> {
@@ -7393,6 +7470,20 @@ pub fn dummy_linker<T>(engine: &Engine) -> Result<Linker<T>, wasmtime::Error> {
          _pk_length: i32| {
             println!("secp256r1_verify_simple_hash");
             Ok(0i32)
+        },
+    )?;
+
+    linker.func_wrap(
+        "clarity",
+        "get_bitcoin_tx_output",
+        |_tx_offset: i32,
+         _tx_length: i32,
+         _vout_lo: i64,
+         _vout_hi: i64,
+         _return_offset: i32,
+         _return_length: i32| {
+            println!("get_bitcoin_tx_output");
+            Ok(())
         },
     )?;
 

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -6190,24 +6190,6 @@ fn link_verify_merkle_proof_fn(
         })
 }
 
-/// The return type of `get-bitcoin-tx-output?`:
-/// `(response { script: (buff 1024), amount: uint, txid: (buff 32) } uint)`.
-fn get_bitcoin_tx_output_result_type() -> Result<TypeSignature, VmExecutionError> {
-    let ok_ty: TypeSignature = TupleTypeSignature::try_from(vec![
-        (
-            ClarityName::from_literal("script"),
-            TypeSignature::BUFFER_1024.clone(),
-        ),
-        (ClarityName::from_literal("amount"), TypeSignature::UIntType),
-        (
-            ClarityName::from_literal("txid"),
-            TypeSignature::BUFFER_32.clone(),
-        ),
-    ])?
-    .into();
-    Ok(TypeSignature::new_response(ok_ty, TypeSignature::UIntType)?)
-}
-
 /// Link host interface function, `get_bitcoin_tx_output`, into the Wasm module.
 /// This function is called for the Clarity expression, `get-bitcoin-tx-output?`.
 fn link_get_bitcoin_tx_output_fn(

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -6230,7 +6230,19 @@ fn link_get_bitcoin_tx_output_fn(
                     .and_then(|export| export.into_memory())
                     .ok_or(VmExecutionError::Wasm(WasmError::MemoryNotFound))?;
 
-                let ret_ty = get_bitcoin_tx_output_result_type()?;
+                let ok_ty: TypeSignature = TupleTypeSignature::try_from(vec![
+                    (
+                        ClarityName::from_literal("script"),
+                        TypeSignature::BUFFER_1024.clone(),
+                    ),
+                    (ClarityName::from_literal("amount"), TypeSignature::UIntType),
+                    (
+                        ClarityName::from_literal("txid"),
+                        TypeSignature::BUFFER_32.clone(),
+                    ),
+                ])?
+                .into();
+                let ret_ty = TypeSignature::new_response(ok_ty, TypeSignature::UIntType)?;
                 let repr_size = get_type_size(&ret_ty);
 
                 let tx_bytes = read_bytes_from_wasm(memory, &mut caller, tx_offset, tx_length)?;

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -360,6 +360,13 @@
                                                                  (param $result_offset i32)
                                                                  (param $result_length i32)))
 
+    (import "clarity" "get_bitcoin_tx_output" (func $stdlib.get_bitcoin_tx_output
+                                                                 (param $tx_offset i32)
+                                                                 (param $tx_length i32)
+                                                                 (param $vout_lo i64)
+                                                                 (param $vout_hi i64)
+                                                                 (param $return_offset i32)
+                                                                 (param $return_length i32)))
     (import "clarity" "principal_of" (func $stdlib.principal_of (param $key_offset i32)
                                                                 (param $key_length i32)
                                                                 (param $principal_offset i32)

--- a/clar2wasm/src/words/bitcoin.rs
+++ b/clar2wasm/src/words/bitcoin.rs
@@ -57,8 +57,6 @@ impl ComplexWord for GetTxOutput {
         check_args!(generator, builder, 2, args.len(), ArgumentCountCheck::Exact);
 
         generator.traverse_expr(builder, args.get_expr(0)?)?;
-
-        // `vout`, pushed as the low/high `i64` pair of a Clarity `uint`
         generator.traverse_expr(builder, args.get_expr(1)?)?;
 
         // Reserve stack space for the host-function to write the result

--- a/clar2wasm/src/words/bitcoin.rs
+++ b/clar2wasm/src/words/bitcoin.rs
@@ -37,6 +37,53 @@ impl ComplexWord for VerifyMerkleProof {
     }
 }
 
+#[derive(Debug)]
+pub struct GetTxOutput;
+
+impl Word for GetTxOutput {
+    fn name(&self) -> ClarityName {
+        ClarityName::from_literal("get-bitcoin-tx-output?")
+    }
+}
+
+impl ComplexWord for GetTxOutput {
+    fn traverse(
+        &self,
+        generator: &mut WasmGenerator,
+        builder: &mut walrus::InstrSeqBuilder,
+        expr: &SymbolicExpression,
+        args: &[SymbolicExpression],
+    ) -> Result<(), GeneratorError> {
+        check_args!(generator, builder, 2, args.len(), ArgumentCountCheck::Exact);
+
+        generator.traverse_expr(builder, args.get_expr(0)?)?;
+
+        // `vout`, pushed as the low/high `i64` pair of a Clarity `uint`
+        generator.traverse_expr(builder, args.get_expr(1)?)?;
+
+        // Reserve stack space for the host-function to write the result
+        let ret_ty = generator
+            .get_expr_type(expr)
+            .ok_or_else(|| {
+                GeneratorError::TypeError(
+                    "result of get-bitcoin-tx-output? should be typed".to_owned(),
+                )
+            })?
+            .clone();
+
+        let (result_local, result_size) =
+            generator.create_call_stack_local(builder, &ret_ty, true, true);
+        builder.local_get(result_local).i32_const(result_size);
+
+        // Call the host interface function, `get_bitcoin_tx_output`
+        builder.call(generator.func_by_name("stdlib.get_bitcoin_tx_output"));
+
+        generator.read_from_memory(builder, result_local, 0, &ret_ty)?;
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 #[cfg(not(any(
     feature = "test-clarity-v1",
@@ -46,11 +93,12 @@ impl ComplexWord for VerifyMerkleProof {
     feature = "test-clarity-v5"
 )))]
 mod tests {
+    use clarity::util::hash::{to_hex, Sha256Sum};
     use clarity::vm::errors::{RuntimeCheckErrorKind, VmExecutionError};
     use clarity::vm::types::{
-        BuffData, BufferLength, SequenceData, SequenceSubtype, TypeSignature,
+        BuffData, BufferLength, SequenceData, SequenceSubtype, TupleData, TypeSignature,
     };
-    use clarity::vm::Value;
+    use clarity::vm::{ClarityName, Value};
 
     use crate::tools::{crosscheck, evaluate};
 
@@ -232,6 +280,210 @@ mod tests {
                     .to_error_string(),
                 ),
             )),
+        );
+    }
+
+    /// A minimal non-SegWit tx: version 1, one input, one P2WPKH output of
+    /// 1000 sats, locktime 0.
+    const SAMPLE_TX: &str = concat!(
+        "01000000",                                                         // version
+        "01",                                                               // n_in
+        "0000000000000000000000000000000000000000000000000000000000000000", // prev txid
+        "00000000",                                                         // prev vout
+        "00",                                                               // scriptSig len
+        "ffffffff",                                                         // sequence
+        "01",                                                               // n_out
+        "e803000000000000",                                                 // amount = 1000
+        "16",                                                               // script len = 22
+        "0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",                     // P2WPKH
+        "00000000",                                                         // locktime
+    );
+    const SAMPLE_SCRIPT: &str = "0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    /// Internal byte order, i.e. the raw double-SHA-256 of `SAMPLE_TX`.
+    const SAMPLE_TXID: &str = "026ac2ecda2e5b8be7e9ba0658e9bebe75671fe06335116a4c6712bc822438e4";
+
+    /// The same transaction serialized with a SegWit marker, flag and witness
+    /// stack. The witness is excluded from the txid preimage, so this yields
+    /// the same txid as `SAMPLE_TX`.
+    const SAMPLE_TX_SEGWIT: &str = concat!(
+        "01000000",                                                         // version
+        "0001",                                                             // marker + flag
+        "01",                                                               // n_in
+        "0000000000000000000000000000000000000000000000000000000000000000", // prev txid
+        "00000000",                                                         // prev vout
+        "00",                                                               // scriptSig len
+        "ffffffff",                                                         // sequence
+        "01",                                                               // n_out
+        "e803000000000000",                                                 // amount = 1000
+        "16",                                                               // script len = 22
+        "0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",                     // P2WPKH
+        "01",                                                               // 1 witness item
+        "02",                                                               // item length
+        "5151",                                                             // OP_1 OP_1
+        "00000000",                                                         // locktime
+    );
+
+    /// The Bitcoin genesis block coinbase transaction. Its txid is
+    /// [`GENESIS_TXID`].
+    const GENESIS_COINBASE: &str = concat!(
+        "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d",
+        "04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f",
+        "6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2",
+        "052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649",
+        "f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000",
+    );
+    const GENESIS_SCRIPT: &str = concat!(
+        "4104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4",
+        "f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac",
+    );
+
+    /// The expected `(ok { script, amount, txid })` value.
+    fn expect_output(
+        script: &str,
+        amount: u128,
+        txid: &str,
+    ) -> Result<Option<Value>, VmExecutionError> {
+        let tuple = TupleData::from_data(vec![
+            (
+                ClarityName::from_literal("script"),
+                Value::buff_from(hex::decode(script).unwrap()).unwrap(),
+            ),
+            (ClarityName::from_literal("amount"), Value::UInt(amount)),
+            (
+                ClarityName::from_literal("txid"),
+                Value::buff_from(hex::decode(txid).unwrap()).unwrap(),
+            ),
+        ])
+        .unwrap();
+        Ok(Some(Value::okay(Value::Tuple(tuple)).unwrap()))
+    }
+
+    /// Bitcoin's double-SHA-256, in internal byte order. For a non-SegWit
+    /// transaction the txid preimage is the raw serialization.
+    fn txid_of(raw: &[u8]) -> String {
+        to_hex(&Sha256Sum::from_data(Sha256Sum::from_data(raw).as_bytes()).0)
+    }
+
+    /// A single-output tx whose `scriptPubKey` is `script_len` bytes of OP_1.
+    fn tx_with_script_of_len(script_len: usize) -> Vec<u8> {
+        let mut raw = hex::decode(concat!(
+            "01000000",                                                         // version
+            "01",                                                               // n_in
+            "0000000000000000000000000000000000000000000000000000000000000000", // prev txid
+            "00000000",                                                         // prev vout
+            "00",                                                               // scriptSig len
+            "ffffffff",                                                         // sequence
+            "01",                                                               // n_out
+            "e803000000000000",                                                 // amount = 1000
+        ))
+        .unwrap();
+        // CompactSize length prefix, always in the 0xfd + u16 range here
+        raw.push(0xfd);
+        raw.extend_from_slice(&(script_len as u16).to_le_bytes());
+        raw.extend(std::iter::repeat_n(0x51u8, script_len));
+        raw.extend_from_slice(&[0, 0, 0, 0]); // locktime
+        raw
+    }
+
+    #[test]
+    fn less_than_two_args() {
+        let result = evaluate(&format!("(get-bitcoin-tx-output? 0x{SAMPLE_TX})"));
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("expecting 2 arguments, got 1"));
+    }
+
+    #[test]
+    fn more_than_two_args() {
+        let result = evaluate(&format!("(get-bitcoin-tx-output? 0x{SAMPLE_TX} u0 u0)"));
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("expecting 2 arguments, got 3"));
+    }
+
+    #[test]
+    fn non_segwit_output() {
+        crosscheck(
+            &format!("(get-bitcoin-tx-output? 0x{SAMPLE_TX} u0)"),
+            expect_output(SAMPLE_SCRIPT, 1000, SAMPLE_TXID),
+        );
+    }
+
+    #[test]
+    fn segwit_output_has_the_same_txid() {
+        crosscheck(
+            &format!("(get-bitcoin-tx-output? 0x{SAMPLE_TX_SEGWIT} u0)"),
+            expect_output(SAMPLE_SCRIPT, 1000, SAMPLE_TXID),
+        );
+    }
+
+    #[test]
+    fn genesis_coinbase() {
+        crosscheck(
+            &format!("(get-bitcoin-tx-output? 0x{GENESIS_COINBASE} u0)"),
+            expect_output(GENESIS_SCRIPT, 5_000_000_000, GENESIS_TXID),
+        );
+    }
+
+    /// `(err u1)`: the bytes do not deserialize as a Bitcoin transaction.
+    #[test]
+    fn truncated_tx_is_err_u1() {
+        let truncated = &SAMPLE_TX[..SAMPLE_TX.len() - 2];
+        crosscheck(
+            &format!("(get-bitcoin-tx-output? 0x{truncated} u0)"),
+            Ok(Some(Value::err_uint(1))),
+        );
+    }
+
+    #[test]
+    fn empty_tx_is_err_u1() {
+        crosscheck(
+            "(get-bitcoin-tx-output? 0x u0)",
+            Ok(Some(Value::err_uint(1))),
+        );
+    }
+
+    /// `(err u2)`: the transaction parses, but has no such output.
+    #[test]
+    fn vout_out_of_range_is_err_u2() {
+        crosscheck(
+            &format!("(get-bitcoin-tx-output? 0x{SAMPLE_TX} u1)"),
+            Ok(Some(Value::err_uint(2))),
+        );
+    }
+
+    /// A `vout` past `u64::MAX` is out of range rather than a truncation.
+    #[test]
+    fn huge_vout_is_err_u2() {
+        crosscheck(
+            &format!(
+                "(get-bitcoin-tx-output? 0x{SAMPLE_TX} u340282366920938463463374607431768211455)"
+            ),
+            Ok(Some(Value::err_uint(2))),
+        );
+    }
+
+    /// `(err u3)`: the output's `scriptPubKey` is over the 1024-byte cap.
+    #[test]
+    fn oversized_script_is_err_u3() {
+        let raw = tx_with_script_of_len(1025);
+        crosscheck(
+            &format!("(get-bitcoin-tx-output? 0x{} u0)", to_hex(&raw)),
+            Ok(Some(Value::err_uint(3))),
+        );
+    }
+
+    /// A `scriptPubKey` of exactly 1024 bytes is still accepted.
+    #[test]
+    fn script_at_the_size_limit_is_accepted() {
+        let raw = tx_with_script_of_len(1024);
+        crosscheck(
+            &format!("(get-bitcoin-tx-output? 0x{} u0)", to_hex(&raw)),
+            expect_output(&"51".repeat(1024), 1000, &txid_of(&raw)),
         );
     }
 }

--- a/clar2wasm/src/words/mod.rs
+++ b/clar2wasm/src/words/mod.rs
@@ -62,6 +62,7 @@ pub(crate) static COMPLEX_WORDS: &[&'static dyn ComplexWord] = &[
     &to_ascii::ToAscii,
     &bindings::Let,
     &bitcoin::VerifyMerkleProof,
+    &bitcoin::GetTxOutput,
     &blockinfo::AtBlock,
     &blockinfo::GetBlockInfo,
     &blockinfo::GetBurnBlockInfo,

--- a/clar2wasm/tests/wasm-generation/bitcoin.rs
+++ b/clar2wasm/tests/wasm-generation/bitcoin.rs
@@ -8,7 +8,8 @@
 mod clarity_v6 {
     use clar2wasm::tools::{crosscheck, crosscheck_validate};
     use clarity::util::hash::{to_hex, Sha256Sum};
-    use clarity::vm::Value;
+    use clarity::vm::types::TupleData;
+    use clarity::vm::{ClarityName, Value};
     use proptest::prelude::*;
 
     /// Bitcoin's double-SHA-256.
@@ -55,6 +56,34 @@ mod clarity_v6 {
         (0..count)
             .map(|i| dsha256(&(i as u64).to_le_bytes()))
             .collect()
+    }
+    /// Serialize a single-output, single-input non-SegWit transaction.
+    fn build_tx(amount: u64, script: &[u8]) -> Vec<u8> {
+        let mut raw = Vec::new();
+        raw.extend_from_slice(&1u32.to_le_bytes()); // version
+        raw.push(0x01); // n_in
+        raw.extend_from_slice(&[0u8; 32]); // prev txid
+        raw.extend_from_slice(&[0u8; 4]); // prev vout
+        raw.push(0x00); // scriptSig len
+        raw.extend_from_slice(&[0xff; 4]); // sequence
+        raw.push(0x01); // n_out
+        raw.extend_from_slice(&amount.to_le_bytes());
+        if script.len() < 0xfd {
+            raw.push(script.len() as u8);
+        } else {
+            raw.push(0xfd);
+            raw.extend_from_slice(&(script.len() as u16).to_le_bytes());
+        }
+        raw.extend_from_slice(script);
+        raw.extend_from_slice(&[0u8; 4]); // locktime
+        raw
+    }
+
+    /// Bitcoin's double-SHA-256, in internal byte order.
+    fn txid_of(raw: &[u8]) -> Vec<u8> {
+        Sha256Sum::from_data(Sha256Sum::from_data(raw).as_bytes())
+            .0
+            .to_vec()
     }
 
     proptest! {
@@ -125,6 +154,64 @@ mod clarity_v6 {
                 ),
                 |_|{}
             )
+        }
+        /// Arbitrary bytes are almost never a valid transaction, but whatever
+        /// the outcome, the compiled version must agree with the interpreter.
+        #[test]
+        fn crossprop_get_bitcoin_tx_output_arbitrary_bytes(
+            raw in prop::collection::vec(any::<u8>(), 0usize..=128usize),
+            vout in 0u32..4)
+        {
+            crosscheck_validate(
+                &format!("(get-bitcoin-tx-output? 0x{} u{vout})", to_hex(&raw)), |_|{}
+            )
+        }
+
+        /// A well-formed transaction round-trips to its own output.
+        #[test]
+        fn crossprop_get_bitcoin_tx_output_valid_tx(
+            amount in any::<u64>(),
+            script in prop::collection::vec(any::<u8>(), 0usize..=1024usize))
+        {
+            let raw = build_tx(amount, &script);
+            let tuple = TupleData::from_data(vec![
+                (ClarityName::from_literal("script"), Value::buff_from(script).unwrap()),
+                (ClarityName::from_literal("amount"), Value::UInt(u128::from(amount))),
+                (ClarityName::from_literal("txid"), Value::buff_from(txid_of(&raw)).unwrap()),
+            ]).unwrap();
+
+            crosscheck(
+                &format!("(get-bitcoin-tx-output? 0x{} u0)", to_hex(&raw)),
+                Ok(Some(Value::okay(Value::Tuple(tuple)).unwrap()))
+            );
+        }
+
+        /// The transaction has exactly one output, so every other index is
+        /// out of range.
+        #[test]
+        fn crossprop_get_bitcoin_tx_output_out_of_range(
+            amount in any::<u64>(),
+            script in prop::collection::vec(any::<u8>(), 0usize..=64usize),
+            vout in 1u128..=u128::MAX)
+        {
+            let raw = build_tx(amount, &script);
+            crosscheck(
+                &format!("(get-bitcoin-tx-output? 0x{} u{vout})", to_hex(&raw)),
+                Ok(Some(Value::err_uint(2)))
+            );
+        }
+
+        /// Anything over the 1024-byte `scriptPubKey` cap is `(err u3)`.
+        #[test]
+        fn crossprop_get_bitcoin_tx_output_oversized_script(
+            amount in any::<u64>(),
+            extra in 1usize..=512usize)
+        {
+            let raw = build_tx(amount, &vec![0x51u8; 1024 + extra]);
+            crosscheck(
+                &format!("(get-bitcoin-tx-output? 0x{} u0)", to_hex(&raw)),
+                Ok(Some(Value::err_uint(3)))
+            );
         }
     }
 }


### PR DESCRIPTION
Adds [get-bitcoin-tx-output?](https://github.com/stacksgov/sips/blob/main/sips/sip-044/sip-044-clarity6.md#get-bitcoin-tx-output) as part of clarity6.

Stakcks core PR: [here](https://github.com/stacks-network/stacks-core/pull/7559)

closes #836 