### PR TITLE
feat: add secp256k1-decompress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "2.3.0"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#fd230c6db18ba790772fe607d5c404ec8312abec"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#e7b0d5772c5861fabf864e21fa5caa258a057bf1"
 dependencies = [
  "clarity-types",
  "hashbrown 0.15.5",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "clarity-types"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#fd230c6db18ba790772fe607d5c404ec8312abec"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#e7b0d5772c5861fabf864e21fa5caa258a057bf1"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.2"
-source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#fd230c6db18ba790772fe607d5c404ec8312abec"
+source = "git+https://github.com/stacks-network/stacks-core?branch=feat%2Fclarity-wasm-develop#e7b0d5772c5861fabf864e21fa5caa258a057bf1"
 dependencies = [
  "chrono",
  "curve25519-dalek",

--- a/clar2wasm/src/linker.rs
+++ b/clar2wasm/src/linker.rs
@@ -1,5 +1,6 @@
 use std::io::{Cursor, Write as _};
 
+use clarity::util::secp256k1::secp256k1_decompress;
 use clarity::util::secp256r1::{secp256r1_verify, secp256r1_verify_digest};
 use clarity::vm::callables::{DefineType, DefinedFunction};
 use clarity::vm::clarity_wasm::{Cost, CostGlobals};
@@ -169,6 +170,7 @@ pub fn link_host_functions(
     link_sha512_256_fn(linker)?;
     link_secp256k1_recover_fn(linker)?;
     link_secp256k1_verify_fn(linker)?;
+    link_secp256k1_decompress_fn(linker)?;
     link_secp256r1_verify_double_hash_fn(linker)?;
     link_secp256r1_verify_simple_hash_fn(linker)?;
     link_verify_merkle_proof_fn(linker)?;
@@ -5963,6 +5965,72 @@ fn link_secp256k1_verify_fn(
         })
 }
 
+/// Link host interface function, `secp256k1_decompress`, into the Wasm module.
+/// This function is called for the Clarity expression, `secp256k1-decompress?`.
+fn link_secp256k1_decompress_fn(
+    linker: &mut Linker<ClarityWasmContext>,
+) -> Result<(), VmExecutionError> {
+    linker
+        .func_wrap(
+            "clarity",
+            "secp256k1_decompress",
+            |mut caller: Caller<'_, ClarityWasmContext>,
+             msg_offset: i32,
+             msg_length: i32,
+             return_offset: i32,
+             _return_length: i32| {
+                // Get the memory from the caller
+                let memory = caller
+                    .get_export("memory")
+                    .and_then(|export| export.into_memory())
+                    .ok_or(VmExecutionError::Wasm(WasmError::MemoryNotFound))?;
+
+                let ret_ty = TypeSignature::new_response(
+                    TypeSignature::BUFFER_65.clone(),
+                    TypeSignature::UIntType,
+                )?;
+                let repr_size = get_type_size(&ret_ty);
+
+                // Read the message bytes from the memory
+                let msg_bytes = read_bytes_from_wasm(memory, &mut caller, msg_offset, msg_length)?;
+                // To match the interpreter behavior, if the message is the
+                // wrong length, throw a runtime type error.
+                if msg_bytes.len() != 33 {
+                    return Err(RuntimeCheckErrorKind::TypeValueError(
+                        Box::new(TypeSignature::BUFFER_33.clone()),
+                        Value::buff_from(msg_bytes)?.to_error_string(),
+                    )
+                    .into());
+                }
+
+                let result = match secp256k1_decompress(&msg_bytes) {
+                    Ok(pubkey) => Value::okay(Value::buff_from(pubkey.to_vec())?)?,
+                    _ => Value::err_uint(1),
+                };
+
+                // Write the result to the return buffer
+                write_to_wasm(
+                    caller,
+                    memory,
+                    &ret_ty,
+                    return_offset,
+                    return_offset + repr_size,
+                    &result,
+                    true,
+                )?;
+
+                Ok(())
+            },
+        )
+        .map(|_| ())
+        .map_err(|e| {
+            VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
+                "secp256k1_decompress".to_string(),
+                e,
+            ))
+        })
+}
+
 fn link_secp256r1_verify_double_hash_fn(
     linker: &mut Linker<ClarityWasmContext>,
 ) -> Result<(), VmExecutionError> {
@@ -6259,7 +6327,7 @@ fn link_principal_of_fn(linker: &mut Linker<ClarityWasmContext>) -> Result<(), V
         .map(|_| ())
         .map_err(|e| {
             VmExecutionError::Wasm(WasmError::UnableToLinkHostFunction(
-                "secp256k1_verify".to_string(),
+                "principal-of".to_string(),
                 e,
             ))
         })
@@ -7292,6 +7360,12 @@ pub fn dummy_linker<T>(engine: &Engine) -> Result<Linker<T>, wasmtime::Error> {
             println!("secp256k1_verify");
             Ok(0i32)
         },
+    )?;
+
+    linker.func_wrap(
+        "clarity",
+        "secp256k1_decompress",
+        |_msg_offset: i32, _msg_length: i32, _return_offset: i32, _return_length: i32| Ok(()),
     )?;
 
     linker.func_wrap(

--- a/clar2wasm/src/standard/standard.wat
+++ b/clar2wasm/src/standard/standard.wat
@@ -354,6 +354,12 @@
                                                                  (param $pk_offset i32)
                                                                  (param $pk_length i32)
                                                                  (result i32)))
+
+    (import "clarity" "secp256k1_decompress" (func $stdlib.secp256k1_decompress (param $msg_offset i32)
+                                                                 (param $msg_length i32)
+                                                                 (param $result_offset i32)
+                                                                 (param $result_length i32)))
+
     (import "clarity" "principal_of" (func $stdlib.principal_of (param $key_offset i32)
                                                                 (param $key_length i32)
                                                                 (param $principal_offset i32)

--- a/clar2wasm/src/words/mod.rs
+++ b/clar2wasm/src/words/mod.rs
@@ -122,6 +122,7 @@ pub(crate) static COMPLEX_WORDS: &[&'static dyn ComplexWord] = &[
     &responses::IsOk,
     &secp256k1::Recover,
     &secp256k1::Verify,
+    &secp256k1::Decompress,
     &secp256r1::Verify,
     &sequences::Append,
     &sequences::AsMaxLen,

--- a/clar2wasm/src/words/secp256k1.rs
+++ b/clar2wasm/src/words/secp256k1.rs
@@ -161,7 +161,7 @@ mod tests {
     };
     use clarity::vm::Value;
 
-    use crate::tools::{crosscheck, crosscheck_expect_failure, evaluate};
+    use crate::tools::{crosscheck, evaluate};
 
     /// Uncompressed form of the compressed key
     /// 0x0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352,
@@ -530,7 +530,7 @@ mod tests {
     )))]
     #[test]
     fn test_secp256k1_decompress_public_key_too_long() {
-        crosscheck_expect_failure(
+        crate::tools::crosscheck_expect_failure(
             "(secp256k1-decompress? 0x02000000000000000000000000000000000000000000000000000000000000000000)",
         );
     }

--- a/clar2wasm/src/words/secp256k1.rs
+++ b/clar2wasm/src/words/secp256k1.rs
@@ -163,18 +163,6 @@ mod tests {
 
     use crate::tools::{crosscheck, evaluate};
 
-    /// Uncompressed form of the compressed key
-    /// 0x0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352,
-    /// reused across the `secp256k1-decompress?` tests.
-    #[cfg(not(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    )))]
-    const UNCOMPRESSED: &str = "0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6";
-
     /// Expected `(ok <65-byte buffer>)` for the given hex-encoded public key.
     #[cfg(not(any(
         feature = "test-clarity-v1",
@@ -393,201 +381,129 @@ mod tests {
         feature = "test-clarity-v4",
         feature = "test-clarity-v5"
     )))]
-    #[test]
-    fn test_secp256k1_decompress_0_arguments() {
-        let result = evaluate("(secp256k1-decompress? )");
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("expecting 1 arguments, got 0"));
-    }
+    mod decompress {
+        use super::*;
 
-    #[cfg(not(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    )))]
-    #[test]
-    fn test_secp256k1_decompress_2_arguments() {
-        let result = evaluate("(secp256k1-decompress? 1 2)");
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("expecting 1 arguments, got 2"));
-    }
+        /// Uncompressed form of the compressed key
+        /// 0x0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352,
+        /// reused across the `secp256k1-decompress?` tests.
+        const UNCOMPRESSED: &str = "0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6";
 
-    #[cfg(not(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    )))]
-    #[test]
-    fn test_secp256k1_decompress_bad_public_key_buffer_length() {
-        let result = evaluate("(secp256k1-decompress? 0x1)");
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("invalid buffer length, 1"));
-    }
+        #[test]
+        fn test_secp256k1_decompress_0_arguments() {
+            let result = evaluate("(secp256k1-decompress? )");
+            assert!(result.is_err());
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("expecting 1 arguments, got 0"));
+        }
 
-    #[cfg(not(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    )))]
-    #[test]
-    fn test_secp256k1_decompress_bad_public_key_size() {
-        crosscheck(
-            "(secp256k1-decompress? 0x11)",
-            Err(clarity::vm::errors::RuntimeCheckErrorKind::TypeValueError(
-                Box::new(TypeSignature::BUFFER_33),
-                Value::Sequence(SequenceData::Buffer(BuffData {
-                    data: hex::decode("11").unwrap(),
-                }))
-                .to_error_string(),
-            )
-            .into()),
-        );
-    }
+        #[test]
+        fn test_secp256k1_decompress_2_arguments() {
+            let result = evaluate("(secp256k1-decompress? 1 2)");
+            assert!(result.is_err());
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("expecting 1 arguments, got 2"));
+        }
 
-    #[cfg(not(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    )))]
-    #[test]
-    fn test_secp256k1_decompress_bad_public_key() {
-        crosscheck(
-            "(secp256k1-decompress? 0x111111111111111111111111111111111111111111111111111111111111111111)",
-            Ok(Some(Value::err_uint(1)))
-        );
-    }
+        #[test]
+        fn test_secp256k1_decompress_bad_public_key_buffer_length() {
+            let result = evaluate("(secp256k1-decompress? 0x1)");
+            assert!(result.is_err());
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("invalid buffer length, 1"));
+        }
 
-    #[cfg(not(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    )))]
-    #[test]
-    fn test_secp256k1_decompress_0x02_prefix() {
-        crosscheck(
-            "(secp256k1-decompress? 0x0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352)",
-            ok_pubkey(UNCOMPRESSED),
-        );
-    }
+        #[test]
+        fn test_secp256k1_decompress_bad_public_key_size() {
+            crosscheck(
+                "(secp256k1-decompress? 0x11)",
+                Err(clarity::vm::errors::RuntimeCheckErrorKind::TypeValueError(
+                    Box::new(TypeSignature::BUFFER_33),
+                    Value::Sequence(SequenceData::Buffer(BuffData {
+                        data: hex::decode("11").unwrap(),
+                    }))
+                    .to_error_string(),
+                )
+                .into()),
+            );
+        }
 
-    #[cfg(not(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    )))]
-    #[test]
-    fn test_secp256k1_decompress_0x03_prefix() {
-        // i.e. `p - y` of the 0x02 form.
-        crosscheck(
-            "(secp256k1-decompress? 0x0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
-            ok_pubkey("0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777"),
-        );
-    }
+        #[test]
+        fn test_secp256k1_decompress_bad_public_key() {
+            crosscheck(
+                "(secp256k1-decompress? 0x111111111111111111111111111111111111111111111111111111111111111111)",
+                Ok(Some(Value::err_uint(1)))
+            );
+        }
 
-    #[cfg(not(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    )))]
-    #[test]
-    fn test_secp256k1_decompress_all_zero_key() {
-        // x = 0 is a valid field element, but y^2 = 7 has no solution mod p.
-        crosscheck(
-            "(secp256k1-decompress? 0x000000000000000000000000000000000000000000000000000000000000000000)",
-            Ok(Some(Value::err_uint(1))),
-        );
-    }
+        #[test]
+        fn test_secp256k1_decompress_0x02_prefix() {
+            crosscheck(
+                "(secp256k1-decompress? 0x0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352)",
+                ok_pubkey(UNCOMPRESSED),
+            );
+        }
 
-    #[cfg(not(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    )))]
-    #[test]
-    fn test_secp256k1_decompress_public_key_too_long() {
-        crate::tools::crosscheck_expect_failure(
-            "(secp256k1-decompress? 0x02000000000000000000000000000000000000000000000000000000000000000000)",
-        );
-    }
+        #[test]
+        fn test_secp256k1_decompress_0x03_prefix() {
+            // i.e. `p - y` of the 0x02 form.
+            crosscheck(
+                "(secp256k1-decompress? 0x0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
+                ok_pubkey("0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777"),
+            );
+        }
 
-    #[cfg(not(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    )))]
-    #[test]
-    fn test_secp256k1_decompress_oom() {
-        crate::tools::crosscheck_oom(
-            "(secp256k1-decompress? 0x0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352)",
-            ok_pubkey(UNCOMPRESSED),
-        );
-    }
+        #[test]
+        fn test_secp256k1_decompress_all_zero_key() {
+            // x = 0 is a valid field element, but y^2 = 7 has no solution mod p.
+            crosscheck(
+                "(secp256k1-decompress? 0x000000000000000000000000000000000000000000000000000000000000000000)",
+                Ok(Some(Value::err_uint(1))),
+            );
+        }
 
-    #[cfg(not(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    )))]
-    #[test]
-    fn test_secp256k1_decompress_x_out_of_range() {
-        // x = 2^256 - 1 is not a field element (x >= p), so it is rejected
-        // before the curve equation is evaluated.
-        crosscheck(
-            "(secp256k1-decompress? 0x02ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)",
-            Ok(Some(Value::err_uint(1))),
-        );
-    }
+        #[test]
+        fn test_secp256k1_decompress_public_key_too_long() {
+            let result = evaluate("(secp256k1-decompress? 0x02000000000000000000000000000000000000000000000000000000000000000000)");
+            assert!(result.is_err());
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("expecting expression of type '(buff 33)', found '(buff 34)'"));
+        }
 
-    #[cfg(not(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    )))]
-    #[cfg(not(any(
-        feature = "test-clarity-v1",
-        feature = "test-clarity-v2",
-        feature = "test-clarity-v3",
-        feature = "test-clarity-v4",
-        feature = "test-clarity-v5"
-    )))]
-    #[test]
-    fn test_secp256k1_decompress_of_recover_result() {
-        // `secp256k1-recover?` yields the compressed key
-        // 0x03adb8de...786110, which decompresses to the value below.
-        crosscheck(
-            "(secp256k1-decompress? (unwrap-panic (secp256k1-recover? 0xde5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f04 0x8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a1301)))",
-            ok_pubkey("04adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110f600feb84ae5a7b551be5fd6a33e07a04ae1e20f8bac89e58e684625c1292af3"),
-        );
+        #[test]
+        fn test_secp256k1_decompress_oom() {
+            crate::tools::crosscheck_oom(
+                "(secp256k1-decompress? 0x0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352)",
+                ok_pubkey(UNCOMPRESSED),
+            );
+        }
+
+        #[test]
+        fn test_secp256k1_decompress_x_out_of_range() {
+            // x = 2^256 - 1 is not a field element (x >= p), so it is rejected
+            // before the curve equation is evaluated.
+            crosscheck(
+                "(secp256k1-decompress? 0x02ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)",
+                Ok(Some(Value::err_uint(1))),
+            );
+        }
+
+        #[test]
+        fn test_secp256k1_decompress_of_recover_result() {
+            // `secp256k1-recover?` yields the compressed key
+            // 0x03adb8de...786110, which decompresses to the value below.
+            crosscheck(
+                "(secp256k1-decompress? (unwrap-panic (secp256k1-recover? 0xde5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f04 0x8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a1301)))",
+                ok_pubkey("04adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110f600feb84ae5a7b551be5fd6a33e07a04ae1e20f8bac89e58e684625c1292af3"),
+            );
+        }
     }
 }

--- a/clar2wasm/src/words/secp256k1.rs
+++ b/clar2wasm/src/words/secp256k1.rs
@@ -99,6 +99,60 @@ impl ComplexWord for Verify {
     }
 }
 
+#[derive(Debug)]
+pub struct Decompress;
+
+impl Word for Decompress {
+    fn name(&self) -> ClarityName {
+        ClarityName::from_literal("secp256k1-decompress?")
+    }
+}
+
+impl ComplexWord for Decompress {
+    fn traverse(
+        &self,
+        generator: &mut WasmGenerator,
+        builder: &mut walrus::InstrSeqBuilder,
+        expr: &SymbolicExpression,
+        args: &[SymbolicExpression],
+    ) -> Result<(), GeneratorError> {
+        check_args!(generator, builder, 1, args.len(), ArgumentCountCheck::Exact);
+
+        generator.traverse_expr(builder, args.get_expr(0)?)?;
+
+        // Reserve stack space for the host-function to write the result
+        let ret_ty = generator
+            .get_expr_type(expr)
+            .ok_or_else(|| {
+                GeneratorError::TypeError(
+                    "result of secp256k1-decompress? should be typed".to_owned(),
+                )
+            })?
+            .clone();
+
+        let (result_local, result_size) =
+            generator.create_call_stack_local(builder, &ret_ty, true, true);
+        builder.local_get(result_local).i32_const(result_size);
+
+        // Call the host interface function, `secp256k1_decompress?`
+        builder.call(
+            generator
+                .module
+                .funcs
+                .by_name("stdlib.secp256k1_decompress")
+                .ok_or_else(|| {
+                    GeneratorError::InternalError(
+                        "stdlib.secp256k1_decompress not found".to_owned(),
+                    )
+                })?,
+        );
+
+        generator.read_from_memory(builder, result_local, 0, &ret_ty)?;
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use clarity::vm::errors::VmExecutionError;
@@ -107,7 +161,33 @@ mod tests {
     };
     use clarity::vm::Value;
 
-    use crate::tools::{crosscheck, evaluate};
+    use crate::tools::{crosscheck, crosscheck_expect_failure, evaluate};
+
+    /// Uncompressed form of the compressed key
+    /// 0x0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352,
+    /// reused across the `secp256k1-decompress?` tests.
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    const UNCOMPRESSED: &str = "0450863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b23522cd470243453a299fa9e77237716103abc11a1df38855ed6f2ee187e9c582ba6";
+
+    /// Expected `(ok <65-byte buffer>)` for the given hex-encoded public key.
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    fn ok_pubkey(hex_key: &str) -> Result<Option<Value>, VmExecutionError> {
+        Ok(Some(
+            Value::okay(Value::buff_from(hex::decode(hex_key).unwrap()).unwrap()).unwrap(),
+        ))
+    }
 
     #[test]
     fn secp256k1_recover_less_than_two_args() {
@@ -304,5 +384,210 @@ mod tests {
                     })).to_error_string(),
                 ),
             )));
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn test_secp256k1_decompress_0_arguments() {
+        let result = evaluate("(secp256k1-decompress? )");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("expecting 1 arguments, got 0"));
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn test_secp256k1_decompress_2_arguments() {
+        let result = evaluate("(secp256k1-decompress? 1 2)");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("expecting 1 arguments, got 2"));
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn test_secp256k1_decompress_bad_public_key_buffer_length() {
+        let result = evaluate("(secp256k1-decompress? 0x1)");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid buffer length, 1"));
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn test_secp256k1_decompress_bad_public_key_size() {
+        crosscheck(
+            "(secp256k1-decompress? 0x11)",
+            Err(clarity::vm::errors::RuntimeCheckErrorKind::TypeValueError(
+                Box::new(TypeSignature::BUFFER_33),
+                Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: hex::decode("11").unwrap(),
+                }))
+                .to_error_string(),
+            )
+            .into()),
+        );
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn test_secp256k1_decompress_bad_public_key() {
+        crosscheck(
+            "(secp256k1-decompress? 0x111111111111111111111111111111111111111111111111111111111111111111)",
+            Ok(Some(Value::err_uint(1)))
+        );
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn test_secp256k1_decompress_0x02_prefix() {
+        crosscheck(
+            "(secp256k1-decompress? 0x0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352)",
+            ok_pubkey(UNCOMPRESSED),
+        );
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn test_secp256k1_decompress_0x03_prefix() {
+        // i.e. `p - y` of the 0x02 form.
+        crosscheck(
+            "(secp256k1-decompress? 0x0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
+            ok_pubkey("0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777"),
+        );
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn test_secp256k1_decompress_all_zero_key() {
+        // x = 0 is a valid field element, but y^2 = 7 has no solution mod p.
+        crosscheck(
+            "(secp256k1-decompress? 0x000000000000000000000000000000000000000000000000000000000000000000)",
+            Ok(Some(Value::err_uint(1))),
+        );
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn test_secp256k1_decompress_public_key_too_long() {
+        crosscheck_expect_failure(
+            "(secp256k1-decompress? 0x02000000000000000000000000000000000000000000000000000000000000000000)",
+        );
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn test_secp256k1_decompress_oom() {
+        crate::tools::crosscheck_oom(
+            "(secp256k1-decompress? 0x0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352)",
+            ok_pubkey(UNCOMPRESSED),
+        );
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn test_secp256k1_decompress_x_out_of_range() {
+        // x = 2^256 - 1 is not a field element (x >= p), so it is rejected
+        // before the curve equation is evaluated.
+        crosscheck(
+            "(secp256k1-decompress? 0x02ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)",
+            Ok(Some(Value::err_uint(1))),
+        );
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn test_secp256k1_decompress_of_recover_result() {
+        // `secp256k1-recover?` yields the compressed key
+        // 0x03adb8de...786110, which decompresses to the value below.
+        crosscheck(
+            "(secp256k1-decompress? (unwrap-panic (secp256k1-recover? 0xde5b9eb9e7c5592930eb2e30a01369c36586d872082ed8181ee83d2a0ec20f04 0x8738487ebe69b93d8e51583be8eee50bb4213fc49c767d329632730cc193b873554428fc936ca3569afc15f1c9365f6591d6251a89fee9c9ac661116824d3a1301)))",
+            ok_pubkey("04adb8de4bfb65db2cfd6120d55c6526ae9c52e675db7e47308636534ba7786110f600feb84ae5a7b551be5fd6a33e07a04ae1e20f8bac89e58e684625c1292af3"),
+        );
     }
 }

--- a/clar2wasm/tests/wasm-generation/secp256k1.rs
+++ b/clar2wasm/tests/wasm-generation/secp256k1.rs
@@ -1,7 +1,7 @@
 use std::ops::RangeInclusive;
 
 use clar2wasm::tools::{crosscheck, crosscheck_validate};
-use clarity::types::PrivateKey;
+use clarity::types::{PrivateKey, PublicKey};
 use clarity::util::hash::to_hex;
 use clarity::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 use clarity::vm::types::{SequenceSubtype, TypeSignature};
@@ -120,4 +120,44 @@ proptest! {
             |_|{}
         );
     }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn crossprop_secp256k1_decompress_generic(msg in buffer(33))
+    {
+        crosscheck_validate(
+            &format!("(secp256k1-decompress? {msg})"), |_|{}
+        )
+    }
+
+    #[cfg(not(any(
+        feature = "test-clarity-v1",
+        feature = "test-clarity-v2",
+        feature = "test-clarity-v3",
+        feature = "test-clarity-v4",
+        feature = "test-clarity-v5"
+    )))]
+    #[test]
+    fn crossprop_secp256k1_decompress_real_key(
+        private_key in prop::collection::vec(any::<u8>(), 32usize..=32usize))
+    {
+        let mut key = Secp256k1PrivateKey::from_slice(&private_key).unwrap();
+
+        key.set_compress_public(true);
+        let compressed = Secp256k1PublicKey::from_private(&key).to_bytes_compressed();
+        key.set_compress_public(false);
+        let uncompressed = Secp256k1PublicKey::from_private(&key).to_bytes();
+
+        crosscheck(
+            &format!("(secp256k1-decompress? 0x{})", to_hex(&compressed)),
+            Ok(Some(Value::okay(Value::buff_from(uncompressed).unwrap()).unwrap()))
+        );
+    }
+
 }

--- a/clar2wasm/tests/wasm-generation/secp256k1.rs
+++ b/clar2wasm/tests/wasm-generation/secp256k1.rs
@@ -1,7 +1,7 @@
 use std::ops::RangeInclusive;
 
 use clar2wasm::tools::{crosscheck, crosscheck_validate};
-use clarity::types::{PrivateKey, PublicKey};
+use clarity::types::PrivateKey;
 use clarity::util::hash::to_hex;
 use clarity::util::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 use clarity::vm::types::{SequenceSubtype, TypeSignature};

--- a/clar2wasm/tests/wasm-generation/secp256k1.rs
+++ b/clar2wasm/tests/wasm-generation/secp256k1.rs
@@ -147,6 +147,7 @@ proptest! {
     fn crossprop_secp256k1_decompress_real_key(
         private_key in prop::collection::vec(any::<u8>(), 32usize..=32usize))
     {
+        use clarity::types::PublicKey;
         let mut key = Secp256k1PrivateKey::from_slice(&private_key).unwrap();
 
         key.set_compress_public(true);


### PR DESCRIPTION
Addes [secp256k1-decompress?](https://github.com/stacksgov/sips/blob/main/sips/sip-044/sip-044-clarity6.md#add-secp256k1-decompress-function) as part of clarity 6.

Stakcs core PR: [here](https://github.com/stacks-network/stacks-core/pull/7560)

Closes #834 